### PR TITLE
Reformatting misc and newcat moon events

### DIFF
--- a/resources/dicts/events/injury/beach.json
+++ b/resources/dicts/events/injury/beach.json
@@ -1,103 +1,24 @@
 [
     {
-        "event_id": "bch_injury",
-        "biome": [
-            "beach"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c couldn't help but try to show off by climbing the tallest tree {PRONOUN/m_c/subject} could find. {PRONOUN/m_c/poss/CAP} plan backfired when {PRONOUN/m_c/subject} fell out of the tree.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "trait": [
-                "adventurous",
-                "ambitious",
-                "bold",
-                "childish",
-                "confident",
-                "daring",
-                "playful",
-                "troublesome"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "broken bone"
-                ],
-                "scars": [
-                    "SIDE"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred after falling from a tall tree.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after falling from a tall tree."
-        }
-    },
-    {
-        "event_id": "bch_injury",
-        "biome": [
-            "beach"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
+        "event_id": "bch_injury_waterinlungs_anyapprentic1",
+        "biome": ["beach"],
+        "camp": ["any"],
+        "season": ["any"],
         "weight": 20,
         "event_text": "m_c went out of camp alone to practice swimming in the ocean; unfortunately, {PRONOUN/m_c/poss} inexperience led to {PRONOUN/m_c/object} being swept up by a riptide. r_c heard {PRONOUN/m_c/poss} cries and saved {PRONOUN/m_c/object}, but m_c almost drowned.",
         "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": [],
-            "trait": [
-                "adventurous",
-                "ambitious",
-                "bold",
-                "childish",
-                "confident",
-                "daring",
-                "playful",
-                "troublesome"
-            ]
+            "age": ["adolescent"],
+            "status": ["apprentice"],
+            "trait": ["adventurous", "ambitious", "bold", "childish", "confident", "daring", "playful", "troublesome"]
         },
         "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": []
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "status": ["any"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "water in their lungs"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["water in their lungs"]
             }
         ],
         "history": {
@@ -105,184 +26,97 @@
         },
         "relationships": [
             {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect",
-                    "dislike"
-                ],
-                "amount": -5
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
+                "mutual": true,
+                "values": ["platonic", "comfort", "trust", "respect"],
+                "amount": 10
+            },
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
+                "mutual": true,
+                "values": ["dislike"],
+                "amount": -10
             }
         ]
     },
     {
-        "event_id": "bch_injury",
-        "biome": [
-            "beach"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
+        "event_id": "bch_injury_crackedpads_anyapprentice1",
+        "biome": ["beach"],
+        "camp": ["any"],
+        "season": ["any"],
         "weight": 20,
         "event_text": "m_c's paw pads aren't used to all the salt water {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} been traipsing around in since becoming an apprentice, they've become cracked and sore.",
         "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
+            "age": ["adolescent"],
+            "status": ["apprentice"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "cracked pads"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["cracked pads"]
             }
         ]
     },
     {
-        "event_id": "bch_injury",
-        "biome": [
-            "beach"
-        ],
-        "camp": [
-            "camp2"
-        ],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [],
+        "event_id": "bch_injury_bruises_anymultitraitapprentice1",
+        "biome": ["beach"],
+        "camp": ["camp2"],
+        "season": ["leaf-bare"],
         "weight": 20,
         "event_text": "m_c was dashing around the apprentice rock, when {PRONOUN/m_c/subject} slipped and fell into the high tide waters of the cave. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} alright, though a bit bruised and embarrassed.",
         "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "trait": [
-                "adventurous",
-                "bold",
-                "childish",
-                "daring",
-                "playful",
-                "troublesome"
-            ]
+            "age": ["adolescent"],
+            "status": ["apprentice"],
+            "trait": ["adventurous", "bold", "childish", "daring", "playful", "troublesome"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "bruises"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["bruises"]
             }
         ]
     },
     {
-        "event_id": "bch_injury",
-        "biome": [
-            "beach"
-        ],
-        "camp": [
-            "camp1"
-        ],
-        "season": [
-            "greenleaf",
-            "newleaf",
-            "leaf-fall"
-        ],
-        "tags": [],
+        "event_id": "bch_injury_bruises_multimultitraitapprentice1",
+        "biome": ["beach"],
+        "camp": ["camp1"],
+        "season": ["greenleaf", "newleaf", "leaf-fall"],
         "weight": 20,
         "event_text": "m_c was messing around in the tide pools of the camp clearing, when {PRONOUN/m_c/poss} paw slipped and {PRONOUN/m_c/subject} fell in face first. {PRONOUN/m_c/poss/CAP} pride is wounded, but otherwise {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} only bruised.",
         "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "trait": [
-                "adventurous",
-                "bold",
-                "childish",
-                "daring",
-                "playful",
-                "troublesome"
-            ]
+            "age": ["adolescent"],
+            "status": ["apprentice"],
+            "trait": ["adventurous", "bold", "childish", "daring", "playful", "troublesome"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "bruises"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["bruises"]
             }
         ]
     },
     {
-        "event_id": "bch_injury",
-        "biome": [
-            "beach"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "leaf-fall",
-            "leaf-bare"
-        ],
-        "tags": [],
+        "event_id": "bch_injury_shivering_multiapprentice1",
+        "biome": ["beach"],
+        "camp": ["any"],
+        "season": ["leaf-fall", "leaf-bare"],
         "weight": 20,
         "event_text": "m_c unwisely decided to go out swimming alone after r_c dared {PRONOUN/m_c/object} to. {PRONOUN/m_c/subject/CAP} made it back, but ended up drenched and shivering violently in the cold air.",
         "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": []
+            "age": ["adolescent"],
+            "status": ["apprentice"]
         },
         "r_c": {
-            "age": [],
-            "status": [],
-            "trait": [
-                "adventurous",
-                "bold",
-                "childish",
-                "daring",
-                "playful",
-                "troublesome"
-            ]
+            "age": ["any"],
+            "status": ["any"],
+            "trait": ["adventurous", "bold", "childish", "daring", "playful", "troublesome"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "shivering"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["shivering"]
             }
         ],
         "history": {
@@ -290,60 +124,35 @@
         },
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "respect"
-                ],
-                "amount": 5
-            }
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "mutual": false,
+                "values": ["respect"],
+                "amount": 10
+            }  
         ]
     },
     {
-        "event_id": "bch_injury",
-        "biome": [
-            "beach"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
+        "event_id": "bch_injury_dehydrated_anyapprentice1",
+        "biome": ["beach"],
+        "camp": ["any"],
+        "season": ["any"],
         "weight": 20,
         "event_text": "m_c rarely pays attention when r_c talks about proper ocean safety, and it shows when m_c gets thirsty on patrol and drinks salt water. {PRONOUN/m_c/subject/CAP} {VERB/m_c/come/comes} back to camp severely dehydrated.",
         "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": [
-                "app/mentor"
-            ],
-            "trait": [
-                "troublesome",
-                "strange"
-            ]
+            "age": ["adolescent"],
+            "status": ["apprentice"],
+            "relationship_status": ["app/mentor"],
+            "trait": ["troublesome", "strange"]
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": ["any"],
+            "status": ["any"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "dehydrated"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["dehydrated"]
             }
         ],
         "history": {
@@ -351,60 +160,39 @@
         },
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike",
-                    "platonic",
-                    "trust",
-                    "respect"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["trust", "respect"],
                 "amount": -5
+            },
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["dislike"],
+                "amount": 5
             }
         ]
     },
     {
-        "event_id": "bch_injury",
-        "biome": [
-            "beach"
-        ],
-        "camp": [
-            "camp1"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
+        "event_id": "bch_injury_clawwound_anycamp1kit1",
+        "biome": ["beach"],
+        "camp": ["camp1"],
+        "season": ["any"],
         "weight": 20,
         "event_text": "m_c was grabbed by a seagull, but luckily r_c saves {PRONOUN/m_c/object}! The kit is still left injured from the ordeal.",
         "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "relationship_status": []
+            "age": ["kitten"],
+            "status": ["kitten"]
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "status": ["any"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "claw-wound"
-                ],
-                "scars": [
-                    "TWO"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["claw-wound"],
+                "scars": ["TWO"]
             }
         ],
         "history": {
@@ -413,64 +201,39 @@
         },
         "relationships": [
             {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "respect",
-                    "dislike"
-                ],
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
+                "values": ["platonic", "comfort", "respect"],
+                "amount": 15
+            },
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
+                "values": ["dislike"],
                 "amount": -5
             }
         ]
     },
     {
-        "event_id": "bch_injury",
-        "biome": [
-            "beach"
-        ],
-        "camp": [
-            "camp1"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
+        "event_id": "bch_injury_clawwound_anycamp1kit2",
+        "biome": ["beach"],
+        "camp": ["camp1"],
+        "season": ["any"],
         "weight": 20,
         "event_text": "m_c was grabbed by an osprey, but luckily r_c saves {PRONOUN/m_c/object}! The kit is still left injured from the ordeal.",
         "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "relationship_status": []
+            "age": ["kitten"],
+            "status": ["kitten"]
         },
         "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": []
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "status": ["any"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "claw-wound"
-                ],
-                "scars": [
-                    "TWO"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["claw-wound"],
+                "scars": ["TWO"]
             }
         ],
         "history": {
@@ -479,71 +242,40 @@
         },
         "relationships": [
             {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect",
-                    "dislike"
-                ],
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
+                "values": ["platonic", "comfort", "trust", "respect"],
+                "amount": 5
+            },
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
+                "values": ["dislike"],
                 "amount": -5
             }
         ]
     },
     {
-        "event_id": "bch_injury",
-        "biome": [
-            "beach"
-        ],
-        "camp": [
-            "camp2"
-        ],
-        "season": [
-            "greenleaf",
-            "newleaf"
-        ],
-        "tags": [],
+        "event_id": "bch_injury_waterinlungs_multikit1",
+        "biome": ["beach"],
+        "camp": ["camp2"],
+        "season": ["greenleaf", "newleaf"],
         "weight": 20,
         "event_text": "r_c dares m_c to try and swim out of camp and m_c can't possibly refuse the challenge. {PRONOUN/m_c/subject/CAP} {VERB/m_c/do/does}n't make it far, however, before {PRONOUN/m_c/poss} meager swimming skills fail {PRONOUN/m_c/object} and {PRONOUN/m_c/subject} nearly {VERB/m_c/drown/drowns} before an adult spots {PRONOUN/m_c/object} and comes to the rescue.",
         "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "relationship_status": [],
-            "trait": [
-                "daring",
-                "impulsive",
-                "attention-seeker"
-            ]
+            "age": ["kitten"],
+            "status": ["kitten"],
+            "trait": ["daring", "impulsive", "attention-seeker"]
         },
         "r_c": {
-            "age": [],
-            "status": [],
-            "trait": [
-                "troublesome",
-                "bossy",
-                "bullying",
-                "daring",
-                "impulsive"
-            ]
+            "age": ["kitten"],
+            "status": ["kitten"],
+            "trait": ["troublesome", "bossy", "bullying", "daring", "impulsive"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "water in their lungs"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["water in their lungs"]
             }
         ],
         "history": {
@@ -551,67 +283,34 @@
         },
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "respect"
-                ],
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["respect"],
                 "amount": -5
             }
         ]
     },
     {
-        "event_id": "bch_injury",
-        "biome": [
-            "beach"
-        ],
-        "camp": [
-            "camp2"
-        ],
-        "season": [
-            "leaf-fall",
-            "leaf-bare"
-        ],
-        "tags": [],
+        "event_id": "bch_injury_shivering_multiapprentice2",
+        "biome": ["beach"],
+        "camp": ["camp2"],
+        "season": ["leaf-fall", "leaf-bare"],
         "weight": 20,
         "event_text": "r_c dares m_c to try and swim out of camp. m_c can't possibly refuse the challenge, but the water is freezing when {PRONOUN/m_c/subject} jump in. Though an adult quickly notices and scoops {PRONOUN/m_c/object} out, m_c is still shivering violently from the cold.",
         "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "relationship_status": [],
-            "trait": [
-                "daring",
-                "impulsive",
-                "attention-seeker"
-            ]
+            "age": ["kitten"],
+            "status": ["kitten"],
+            "trait": ["daring", "impulsive", "attention-seeker"]
         },
         "r_c": {
-            "age": [],
-            "status": [],
-            "trait": [
-                "troublesome",
-                "bossy",
-                "bullying",
-                "daring",
-                "impulsive"
-            ]
+            "age": ["kitten"],
+            "status": ["kitten"],
+            "trait": ["troublesome", "bossy", "bullying", "daring", "impulsive"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "shivering"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["shivering"]
             }
         ],
         "history": {
@@ -619,268 +318,125 @@
         },
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "respect"
-                ],
-                "amount": -5
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": ["respect"],
+                "amount": 10
             }
         ]
     },
     {
-        "event_id": "bch_injury",
-        "biome": [
-            "beach"
-        ],
-        "camp": [
-            "camp1"
-        ],
-        "season": [
-            "greenleaf",
-            "newleaf",
-            "leaf-fall"
-        ],
-        "tags": [],
+        "event_id": "bch_injury_bruises_multibouncykit1",
+        "biome": ["beach"],
+        "camp": ["camp1"],
+        "season": ["greenleaf", "newleaf", "leaf-fall"],
         "weight": 20,
         "event_text": "m_c is hopping around in the tide pools when {PRONOUN/m_c/subject} {VERB/m_c/trip/trips} and {VERB/m_c/fall/falls} onto the rocks. Thankfully, {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} only a bit bruised.",
         "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "trait": [
-                "bouncy"
-            ]
+            "age": ["kitten"],
+            "status": ["kitten"],
+            "trait": ["bouncy"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "bruises"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["bruises"]
             }
         ]
     },
     {
-        "event_id": "bch_injury",
-        "biome": [
-            "beach"
-        ],
-        "camp": [
-            "camp1"
-        ],
-        "season": [
-            "leaf-fall",
-            "leaf-bare"
-        ],
-        "tags": [],
+        "event_id": "bch_injury_bruises_multicamp1multitraitkit1",
+        "biome": ["beach"],
+        "camp": ["camp1"],
+        "season": ["leaf-fall", "leaf-bare"],
         "weight": 20,
         "event_text": "m_c is playing around on the iced-over tide pools, slipping and sliding every which way, when {PRONOUN/m_c/subject} {VERB/m_c/slip/slips} a little too much and take a tumble.",
         "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "trait": [
-                "bouncy",
-                "daring",
-                "impulsive",
-                "noisy",
-                "troublesome",
-                "attention-seeker"
-            ]
+            "age": ["kitten"],
+            "status": ["kitten"],
+            "trait": ["bouncy", "daring", "impulsive", "noisy", "troublesome", "attention-seeker"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "bruises"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["bruises"]
             }
         ]
     },
     {
-        "event_id": "bch_injury",
-        "biome": [
-            "beach"
-        ],
-        "camp": [
-            "camp2"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
+        "event_id": "bch_injury_bruises_anycamp2multitraitkit",
+        "biome": ["beach"],
+        "camp": ["camp2"],
+        "season": ["any"],
         "weight": 20,
         "event_text": "m_c is jumping around on the rocks when {PRONOUN/m_c/subject} {VERB/m_c/slip/slips} and {VERB/m_c/fall/falls}. The soft sand of the cave floor softens {PRONOUN/m_c/poss} landing, but {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} still sporting some new bruises.",
         "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "trait": [
-                "bouncy",
-                "daring",
-                "impulsive",
-                "noisy",
-                "troublesome",
-                "attention-seeker"
-            ]
+            "age": ["kitten"],
+            "status": ["kitten"],
+            "trait": ["bouncy", "daring", "impulsive", "noisy", "troublesome", "attention-seeker"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "bruises"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["bruises"]
             }
         ]
     },
     {
-        "event_id": "bch_injury",
-        "biome": [
-            "beach"
-        ],
-        "camp": [
-            "camp1"
-        ],
-        "season": [
-            "leaf-fall",
-            "leaf-bare"
-        ],
-        "tags": [],
+        "event_id": "bch_injury_scrapes_multicamp1multitraitkit1",
+        "biome": ["beach"],
+        "camp": ["camp1"],
+        "season": ["leaf-fall", "leaf-bare"],
         "weight": 20,
         "event_text": "m_c is playing around on the iced-over tide pools, slipping and sliding every which way, when {PRONOUN/m_c/subject} {VERB/m_c/slip/slips} a little too much and take a tumble.",
         "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "trait": [
-                "bouncy",
-                "daring",
-                "impulsive",
-                "noisy",
-                "troublesome",
-                "attention-seeker"
-            ]
+            "age": ["kitten"],
+            "status": ["kitten"],
+            "trait": ["bouncy", "daring", "impulsive", "noisy", "troublesome", "attention-seeker"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "scrapes"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["scrapes"]
             }
         ]
     },
     {
-        "event_id": "bch_injury",
-        "biome": [
-            "beach"
-        ],
-        "camp": [
-            "camp1"
-        ],
-        "season": [
-            "leaf-fall",
-            "leaf-bare"
-        ],
-        "tags": [],
+        "event_id": "bch_injury_sprain_multicamp1multitraitkit1",
+        "biome": ["beach"],
+        "camp": ["camp1"],
+        "season": ["leaf-fall", "leaf-bare"],
         "weight": 20,
         "event_text": "m_c is playing around on the iced-over tide pools, slipping and sliding every which way, when {PRONOUN/m_c/subject} {VERB/m_c/slip/slips} a little too much and {VERB/m_c/twist/twists} {PRONOUN/m_c/poss} paw.",
         "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "trait": [
-                "bouncy",
-                "daring",
-                "impulsive",
-                "noisy",
-                "troublesome",
-                "attention-seeker"
-            ]
+            "age": ["kitten"],
+            "status": ["kitten"],
+            "trait": ["bouncy", "daring", "impulsive", "noisy", "troublesome", "attention-seeker"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "sprain"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["sprain"]
             }
         ]
     },
     {
-        "event_id": "bch_injury",
-        "biome": [
-            "beach"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf",
-            "newleaf",
-            "leaf-fall"
-        ],
-        "tags": [],
+        "event_id": "bch_injury_snakebite_multimultitraitkit1",
+        "biome": ["beach"],
+        "camp": ["any"],
+        "season": ["greenleaf", "newleaf", "leaf-fall"],
         "weight": 20,
         "event_text": "m_c found a hole in the rocks and, curious as all kits are, stuck {PRONOUN/m_c/poss} paw inside. The whole camp comes running when {PRONOUN/m_c/subject} {VERB/m_c/screech/screeches} in pain. It seems a snake was living in that hole.",
         "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "trait": [
-                "daring",
-                "impulsive",
-                "noisy",
-                "troublesome",
-                "attention-seeker",
-                "inquisitive",
-                "quiet"
-            ]
+            "age": ["kitten"],
+            "status": ["kitten"],
+            "trait": ["daring", "impulsive", "noisy", "troublesome", "attention-seeker", "inquisitive", "quiet"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "snake bite"
-                ],
-                "scars": [
-                    "SNAKE"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["snake bite"],
+                "scars": ["SNAKE"]
             }
         ],
         "history": {
@@ -888,110 +444,44 @@
             "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after a snake bit {PRONOUN/m_c/object}."
         }
     },
+
     {
-        "event_id": "bch_injury",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was climbing a tree when {PRONOUN/m_c/subject} fell. Luckily, {PRONOUN/m_c/subject} {VERB/m_c/were/was} only bruised by the incident.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "bruises"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "bch_injury",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
+        "event_id": "bch_injury_crackedpads_any1",
+        "biome": ["beach"],
+        "camp": ["any"],
+        "season": ["any"],
         "weight": 20,
         "event_text": "m_c stepped on some sharp stones while walking along the shoreline.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": ["any"],
+            "status": ["any"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "cracked pads"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["cracked pads"]
             }
         ]
     },
     {
-        "event_id": "bch_injury",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was climbing a tree and got a splinter from one of the branches.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "small cut"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "bch_injury",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
+        "event_id": "bch_injury_waterinlungs_any1",
+        "biome": ["beach"],
+        "camp": ["any"],
+        "season": ["any"],
         "weight": 20,
         "event_text": "m_c was dragged out into the ocean by the tide, and inhaled a lot of water before managing to get out. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'ve/'s} been hacking and sputtering ever since.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": ["any"],
+            "status": ["any"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "water in their lungs"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["water in their lungs"]
             }
         ],
         "history": {
             "reg_death": "m_c died from water-inhalation after being dragged out to sea."
         }
-    }]
+    }    
+]

--- a/resources/dicts/events/injury/forest.json
+++ b/resources/dicts/events/injury/forest.json
@@ -1,269 +1,39 @@
 [
     {
-        "event_id": "fst_injury_",
-        "biome": [
-            "forest"
-        ],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c went out for a walk, but slipped on the ice and broke a bone.",
-        "m_c": {
-            "age": [
-                "senior",
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "elder"
-            ],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "broken bone"
-                ],
-                "scars": [
-                    "TOETRAP"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred after slipping on ice.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after slipping on ice."
-        }
-    },
-    {
-        "event_id": "fst_injury_",
-        "biome": [
-            "forest"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was grabbed by a hawk, but luckily r_c saves {PRONOUN/m_c/object}! The kit is still left injured from the ordeal.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "claw-wound"
-                ],
-                "scars": [
-                    "TWO"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred as a kit, when a hawk tried to carry {PRONOUN/m_c/object} off.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after a hawk tried to carry {PRONOUN/m_c/object} off."
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "respect",
-                    "dislike"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "fst_injury_",
-        "biome": [
-            "forest"
-        ],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c snuck out of camp and returned cold and shivering, frostbite nipping at {PRONOUN/m_c/poss} paws.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "trait": [
-                "daring",
-                "impulsive",
-                "inquisitive",
-                "troublesome"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "frostbite"
-                ],
-                "scars": [
-                    "FROSTMITT"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by frostbite.",
-            "reg_death": "m_c died after {PRONOUN/m_c/subject} got frostbite sneaking out of camp."
-        }
-    },
-    {
-        "event_id": "fst_injury_",
-        "biome": [
-            "forest"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
+        "event_id": "fst_injury_sprain_anyapprentice1",
+        "biome": ["forest"],
+        "camp": ["any"],
+        "season": ["any"],
         "weight": 20,
         "event_text": "m_c was running around excitedly on patrol when {PRONOUN/m_c/poss} paw landed right in a rabbit hole, twisting uncomfortably. {PRONOUN/m_c/subject/CAP} limped the whole way home.",
         "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "trait": [
-                "adventurous",
-                "bold",
-                "daring",
-                "playful",
-                "childish"
-            ]
+            "age": ["adolescent"],
+            "status": ["apprentice"],
+            "trait": ["adventurous", "bold", "daring", "playful", "childish"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "sprain"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["sprain"]
             }
         ]
     },
     {
-        "event_id": "fst_injury_",
-        "biome": [
-            "forest"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c couldn't help but try to show off by climbing the tallest tree {PRONOUN/m_c/subject} could find. {PRONOUN/m_c/poss/CAP} plan backfired when {PRONOUN/m_c/subject} fell out of the tree.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "trait": [
-                "adventurous",
-                "ambitious",
-                "bold",
-                "childish",
-                "confident",
-                "daring",
-                "playful",
-                "troublesome"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "broken bone"
-                ],
-                "scars": [
-                    "SIDE"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred after falling from a tall tree.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after falling from a tall tree."
-        }
-    },
-    {
-        "event_id": "fst_injury_",
-        "biome": [
-            "forest"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
+        "event_id": "fst_injury_brokenbone_anyapprentice1",
+        "biome": ["forest"],
+        "camp": ["any"],
+        "season": ["any"],
         "weight": 20,
         "event_text": "m_c was practicing {PRONOUN/m_c/poss} tree climbing skills when {PRONOUN/m_c/subject} slipped from a branch! Thankfully {PRONOUN/m_c/subject} survived, though badly injured.",
         "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
+            "age": ["any"],
+            "status": ["apprentice"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "broken bone"
-                ],
-                "scars": [
-                    "SIDE"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["broken bone"],
+                "scars": ["SIDE"]
             }
         ],
         "history": {
@@ -272,38 +42,22 @@
         }
     },
     {
-        "event_id": "fst_injury_",
-        "biome": [
-            "forest"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
+        "event_id": "fst_injury_clawwound_anymultistatus1",
+        "biome": ["forest"],
+        "camp": ["any"],
+        "season": ["any"],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was hunting on a night patrol, and nearly got carried off by an owl! {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} alive, but with many a scratch as proof of {PRONOUN/m_c/poss} adventure.",
         "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
+            "age": ["any"],
+            "status": ["apprentice", "warrior", "leader", "deputy"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "claw-wound"
-                ],
-                "scars": [
-                    "TWO"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["claw-wound"],
+                "scars": ["TWO"]
             }
         ],
         "history": {
@@ -312,46 +66,25 @@
         }
     },
     {
-        "event_id": "fst_injury_",
-        "biome": [
-            "forest"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
+        "event_id": "fst_injury_brokenback_anyapprentice1",
+        "biome": ["forest"],
+        "camp": ["any"],
+        "season": ["any"],
         "weight": 20,
         "event_text": "r_c dares m_c to climb one of the tallest trees in the territory. m_c gets pretty high, but a branch breaks and it's a long way to the ground. r_c goes sprinting for camp to get help.",
         "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": []
+            "age": ["adolescent"],
+            "status": ["apprentice"]
         },
         "r_c": {
-            "age": [],
-            "status": [],
-            "trait": [
-                "adventurous",
-                "bold",
-                "daring",
-                "troublesome"
-            ]
+            "age": ["adolescent"],
+            "status": ["apprentice"],
+            "trait": ["adventurous", "bold", "daring", "troublesome"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "broken back"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["broken back"]
             }
         ],
         "history": {
@@ -359,243 +92,53 @@
         },
         "relationships": [
             {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "dislike",
-                    "platonic",
-                    "comfort",
-                    "trust"
-                ],
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
+                "values": ["dislike"],
+                "amount": 10
+            },
+            {
+                "cats_from": ["m_c"],
+                "cats_to": ["r_c"],
+                "values": ["platonic", "comfort", "trust"],
                 "amount": -5
             }
         ]
     },
     {
-        "event_id": "fst_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was climbing a tree when {PRONOUN/m_c/subject} fell. Luckily, {PRONOUN/m_c/subject} {VERB/m_c/were/was} only bruised by the incident.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "bruises"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "fst_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c trips over an unseen rabbit hole, spraining {PRONOUN/m_c/poss} paw.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "sprain"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "fst_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
+        "event_id": "fst_injury_tornpelt_anyany1",
+        "biome": ["forest"],
+        "camp": ["any"],
+        "season": ["any"],
         "weight": 20,
         "event_text": "m_c was pushing through some dense shrubs and felt the branches tear painfully at {PRONOUN/m_c/poss} pelt.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": ["any"],
+            "status": ["any"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "torn pelt"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["torn pelt"]
             }
         ]
     },
     {
-        "event_id": "fst_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was climbing a tree and got a splinter from one of the branches.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "small cut"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "fst_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was moving some branches out of the way when {PRONOUN/m_c/subject} got a splinter.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "small cut"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "fst_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "leaf-fall",
-            "leaf-bare"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was out wandering the territory for a bit too long and came back with frostbite.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "frostbite"
-                ],
-                "scars": [
-                    "FROSTTAIL"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by frostbite.",
-            "reg_death": "m_c died after {PRONOUN/m_c/subject} got frostbite."
-        }
-    },
-    {
-        "event_id": "fst_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf",
-            "newleaf",
-            "leaf-fall"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c fell into a river, and inhaled a lot of water before managing to get out. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'ve/'s} been hacking and sputtering ever since.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "water in their lungs"
-                ]
-            }
-        ],
-        "history": {
-            "reg_death": "m_c died from water-inhalation after falling in the river."
-        }
-    },
-    {
-        "event_id": "fst_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
+        "event_id": "fst_injury_mangledtail_anyany1",
+        "biome": ["forest"],
+        "camp": ["any"],
+        "season": ["any"],
         "weight": 20,
         "event_text": "m_c's tail was badly injured by a falling tree.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": ["any"],
+            "status": ["any"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "mangled tail"
-                ],
-                "scars": [
-                    "MANTAIL"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["mangled tail"],
+                "scars": ["MANTAIL"]
             }
         ],
         "history": {
@@ -604,31 +147,21 @@
         }
     },
     {
-        "event_id": "fst_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf"
-        ],
-        "tags": [],
+        "event_id": "fst_injury_burn_greenleafany1",
+        "biome": ["forest"],
+        "camp": ["any"],
+        "season": ["greenleaf"],
         "weight": 20,
         "event_text": "A fire rages through the forest. m_c manages to escape, though not unscathed by the experience.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": ["any"],
+            "status": ["any"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "burn"
-                ],
-                "scars": [
-                    "BURNRUMP"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["burn"],
+                "scars": ["BURNRUMP"]
             }
         ],
         "history": {
@@ -637,44 +170,26 @@
         }
     },
     {
-        "event_id": "fst_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf"
-        ],
-        "tags": [],
+        "event_id": "fst_injury_burn_greenleafmultiage1",
+        "biome": ["forest"],
+        "camp": ["any"],
+        "season": ["greenleaf"],
         "weight": 20,
         "event_text": "The dry greenleaf weather leads to a fire bursting to life in camp, dangerously close to the nursery. There's still one kit inside! m_c dives into the den and makes it out, burnt, but with r_c safely swinging in {PRONOUN/m_c/poss} grasp.",
         "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
-            "trait": [
-                "ambitious",
-                "bold",
-                "altruistic",
-                "daring",
-                "fierce",
-                "responsible"
-            ]
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "status": ["any"],
+            "trait": [ "ambitious", "bold", "altruistic", "daring", "fierce", "responsible" ]
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": ["kitten"],
+            "status": ["kitten"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "burn"
-                ],
-                "scars": [
-                    "BURNPAWS"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["severe burn"],
+                "scars": ["BURNPAWS", "BURNBELLY"]
             }
         ],
         "history": {
@@ -683,49 +198,35 @@
         },
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect",
-                    "dislike"
-                ],
-                "amount": -5
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": [ "platonic", "comfort", "trust", "respect"],
+                "amount": 20
+            },
+            {
+                "cats_from": ["r_c"],
+                "cats_to": ["m_c"],
+                "values": [ "dislike"],
+                "amount": -20
             }
         ]
     },
     {
-        "event_id": "fst_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf"
-        ],
-        "tags": [],
+        "event_id": "fst_injury_severeburn_greenleafany1",
+        "biome": ["forest"],
+        "camp": ["any"],
+        "season": ["greenleaf"],
         "weight": 20,
         "event_text": "A fire rages through the forest and m_c manages to escape, though not unscathed by the experience.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": ["any"],
+            "status": ["any"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "severe burn"
-                ],
-                "scars": [
-                    "BURNTAIL"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["severe burn"],
+                "scars": ["BURNTAIL"]
             }
         ],
         "history": {
@@ -734,118 +235,28 @@
         }
     },
     {
-        "event_id": "fst_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "The dry greenleaf weather leads to a fire bursting to life in camp, dangerously close to the nursery. There's still one kit inside! m_c dives into the den and makes it out, burnt, but with r_c safely swinging in {PRONOUN/m_c/poss} grasp.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
-            "trait": [
-                "ambitious",
-                "bold",
-                "altruistic",
-                "daring",
-                "fierce",
-                "responsible"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "severe burn"
-                ],
-                "scars": [
-                    "BURNBELLY"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c's pelt was burned by a forest fire.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} burns after a forest fire."
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect",
-                    "dislike"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "fst_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "newleaf",
-            "leaf-bare"
-        ],
-        "tags": [
-            "FROSTPAWS"
-        ],
+        "event_id": "fst_injury_shivering_multiapprentice1",
+        "biome": ["forest"],
+        "camp": [ "any" ], 
+        "season": [ "newleaf", "leaf-bare" ],
         "weight": 20,
         "event_text": "m_c and r_c talked each other into walking onto the ice of the frozen pond that lay not far from camp. It was a dare at first, but when m_c didn't immediately fall in, r_c joined {PRONOUN/m_c/object}. The two cats playfully slipped around for a bit before the minute cracks reached their ears. r_c fell in first, and, without thinking, m_c leaped in after {PRONOUN/r_c/object}. m_c was able to drag r_c out of the water and the two leaned on each other on the way back to camp.",
         "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
-            "skill": [
-                "SWIMMER,3"
-            ],
-            "trait": [
-                "daring",
-                "adventurous",
-                "oblivious",
-                "bold",
-                "childish"
-            ]
+            "age": ["adolescent"],
+            "status": ["apprentice"],
+            "skill": ["SWIMMER,3"],
+            "trait": ["daring", "adventurous", "oblivious", "bold", "childish"]
         },
         "r_c": {
-            "age": [],
-            "status": [],
-            "trait": [
-                "daring",
-                "adventurous",
-                "oblivious",
-                "bold",
-                "childish"
-            ]
+            "age": ["adolescent"],
+            "status": ["apprentice"],
+            "trait": [ "daring", "adventurous", "oblivious", "bold", "childish" ]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "shivering"
-                ],
-                "scars": []
+                "cats": [ "m_c" ], 
+                "injuries": [ "shivering" ],
+                "scars": ["FROSTPAWS"]
             }
         ],
         "history": {
@@ -854,57 +265,30 @@
         },
         "relationships": [
             {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect",
-                    "dislike"
-                ],
+                "cats_from": [ "r_c" ], 
+                "cats_to": [ "m_c" ],
+                "values": [ "platonic", "comfort", "trust", "respect", "dislike" ],
                 "amount": -5
             }
         ]
     },
     {
-        "event_id": "fst_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
+        "event_id": "fst_injury_headache_anymultitraitmultistatus1",
+        "biome": ["forest"],
+        "camp": [ "any" ], 
+        "season": [ "any" ],
         "weight": 20,
         "event_text": "Chasing a mouse through a dense area, m_c accidentally collides with a low-hanging branch, leaving them to return to camp empty-pawed and with splitting head pain.",
         "m_c": {
-            "age": [],
-            "status": [],
-            "trait": [
-                "ambitious",
-                "childish",
-                "playful",
-                "bold",
-                "daring",
-                "confident",
-                "adventurous",
-                "competitive",
-                "oblivious"
-            ]
+            "age": ["any"],
+            "status": ["apprentice", "warrior", "deputy", "leader"],
+            "trait": [ "ambitious", "childish", "playful", "bold", "daring", "confident", "adventurous", "competitive", "oblivious" ]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "headache"
-                ]
+                "cats": [ "m_c" ], 
+                "injuries": [ "headache" ]
             }
         ]
-    }]
+    }
+]

--- a/resources/dicts/events/injury/general.json
+++ b/resources/dicts/events/injury/general.json
@@ -1,22 +1,348 @@
 [
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_bruises_anykitten1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "newleaf",
+            "greenleaf",
+            "leaf-fall",
+            "leaf-bare"
+        ],
+        "weight": 20,
+        "event_text": "m_c tried to sneak out of the camp, but fell and got a bruise before {PRONOUN/m_c/subject} even left the safety of the camp walls.",
+        "m_c": {
+            "age": [
+                "kitten"
+            ],
+            "status": [
+                "kitten"
+            ],
+            "trait": [
+                "daring",
+                "impulsive",
+                "inquisitive",
+                "troublesome"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "bruises"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_bruises_anykitten2",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "newleaf",
+            "greenleaf",
+            "leaf-fall",
+            "leaf-bare"
+        ],
+        "weight": 20,
+        "event_text": "m_c snuck out of camp and returned a bit bruised, but brimming with pride despite the scolding {PRONOUN/m_c/subject} {VERB/m_c/were/was} given.",
+        "m_c": {
+            "age": [
+                "kitten"
+            ],
+            "status": [
+                "kitten"
+            ],
+            "trait": [
+                "daring",
+                "impulsive",
+                "inquisitive",
+                "troublesome"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "bruises"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_bruises_anykitten3",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "newleaf",
+            "greenleaf",
+            "leaf-fall",
+            "leaf-bare"
+        ],
+        "weight": 20,
+        "event_text": "m_c play-fought a bit too hard and got a little bruised.",
+        "m_c": {
+            "age": [
+                "kitten"
+            ],
+            "status": [
+                "kitten"
+            ],
+            "trait": [
+                "daring",
+                "bouncy",
+                "bullying",
+                "impulsive",
+                "noisy",
+                "troublesome"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "bruises"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_scrapes_anykitten1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "newleaf",
+            "greenleaf",
+            "leaf-fall",
+            "leaf-bare"
+        ],
+        "weight": 20,
+        "event_text": "m_c tried to sneak out of the camp, but fell and scraped {PRONOUN/m_c/poss} paw before {PRONOUN/m_c/subject} even left the safety of the camp walls.",
+        "m_c": {
+            "age": [
+                "kitten"
+            ],
+            "status": [
+                "kitten"
+            ],
+            "trait": [
+                "daring",
+                "impulsive",
+                "inquisitive",
+                "troublesome"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "scrapes"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_scrapes_anykitten2",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "newleaf",
+            "greenleaf",
+            "leaf-fall",
+            "leaf-bare"
+        ],
+        "weight": 20,
+        "event_text": "m_c snuck out of camp and returned scraped up, but brimming with pride despite the scolding {PRONOUN/m_c/subject} {VERB/m_c/were/was} given.",
+        "m_c": {
+            "age": [
+                "kitten"
+            ],
+            "status": [
+                "kitten"
+            ],
+            "trait": [
+                "daring",
+                "impulsive",
+                "inquisitive",
+                "troublesome"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "scrapes"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_scrapes_anykitten3",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "newleaf",
+            "greenleaf",
+            "leaf-fall",
+            "leaf-bare"
+        ],
+        "weight": 20,
+        "event_text": "m_c play-fought a bit too hard and scraped {PRONOUN/m_c/self} up.",
+        "m_c": {
+            "age": [
+                "kitten"
+            ],
+            "status": [
+                "kitten"
+            ],
+            "trait": [
+                "daring",
+                "bouncy",
+                "bullying",
+                "impulsive",
+                "noisy",
+                "troublesome"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "scrapes"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_headache_anykitten1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "newleaf",
+            "greenleaf",
+            "leaf-fall",
+            "leaf-bare"
+        ],
+        "weight": 20,
+        "event_text": "m_c woke up with a mild headache, but got up to play anyways, trying to ignore the nagging pain.",
+        "m_c": {
+            "age": [
+                "kitten"
+            ],
+            "status": [
+                "kitten"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "headache"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_severeheadache_anykit1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
+        "weight": 20,
+        "event_text": "m_c woke up with a splitting headache, and couldn't get out of {PRONOUN/m_c/poss} nest. {PRONOUN/m_c/subject/CAP} spent the entire day curled up in the nursery, trying to avoid light and noise so that the throbbing pain could subside.",
+        "m_c": {
+            "age": [
+                "kitten"
+            ],
+            "status": [
+                "kitten"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "severe headache"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_bruisessore_anymultiage1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "newleaf",
+            "greenleaf",
+            "leaf-fall",
+            "leaf-bare"
+        ],
         "weight": 20,
         "event_text": "m_c had a bad fall while taking a walk through the territory, returning to camp sore and bruised.",
         "m_c": {
             "age": [
-                "senior",
                 "adolescent",
                 "young adult",
                 "adult",
                 "senior adult",
-                "elder"
+                "senior"
             ],
-            "status": []
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -24,15 +350,25 @@
                     "m_c"
                 ],
                 "injuries": [
-                    "bruises"
+                    "bruises",
+                    "sore"
                 ]
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
-        "season": [
+        "event_id": "gen_injury_bruisessore_anymultiageclankits1",
+        "biome": [
             "any"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "newleaf",
+            "greenleaf",
+            "leaf-fall",
+            "leaf-bare"
         ],
         "tags": [
             "clan_kits"
@@ -41,14 +377,15 @@
         "event_text": "m_c was play-fighting with the kits, but may have overdone it a bit. {PRONOUN/m_c/subject/CAP}'ll be sore for the next few days.",
         "m_c": {
             "age": [
-                "senior",
                 "adolescent",
                 "young adult",
                 "adult",
                 "senior adult",
-                "elder"
+                "senior"
             ],
-            "status": [],
+            "status": [
+                "any"
+            ],
             "skill": [
                 "KIT,1"
             ]
@@ -59,94 +396,36 @@
                     "m_c"
                 ],
                 "injuries": [
-                    "bruises"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "clan_kits"
-        ],
-        "weight": 20,
-        "event_text": "m_c was play-fighting with the kits, but may have overdone it a bit. {PRONOUN/m_c/subject/CAP}'ll be sore for the next few days.",
-        "m_c": {
-            "age": [
-                "senior",
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "elder"
-            ],
-            "status": [],
-            "skill": [
-                "KIT,1"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
+                    "bruises",
                     "sore"
                 ]
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
-        "season": [
+        "event_id": "gen_injury_jointpain_anysenioradultsenior1",
+        "biome": [
             "any"
         ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c had a bad fall while taking a walk through the territory, and comes back to camp quite sore.",
-        "m_c": {
-            "age": [
-                "senior",
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "elder"
-            ],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "sore"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
+        "camp": [
             "any"
         ],
-        "tags": [],
+        "season": [
+            "newleaf",
+            "greenleaf",
+            "leaf-fall",
+            "leaf-bare"
+        ],
         "weight": 20,
         "event_text": "The weather has been bad lately, and m_c can feel it in {PRONOUN/m_c/poss} bones.",
         "m_c": {
             "age": [
-                "senior",
-                "adolescent",
-                "young adult",
-                "adult",
                 "senior adult",
-                "elder"
+                "senior"
             ],
-            "status": []
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -160,23 +439,29 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
-        "season": [
+        "event_id": "gen_injury_jointpain_anysenioradultsenior2",
+        "biome": [
             "any"
         ],
-        "tags": [],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "newleaf",
+            "greenleaf",
+            "leaf-fall",
+            "leaf-bare"
+        ],
         "weight": 20,
         "event_text": "m_c can feel {PRONOUN/m_c/poss} bones and joints aching. Bad weather must be on its way.",
         "m_c": {
             "age": [
-                "senior",
-                "adolescent",
-                "young adult",
-                "adult",
                 "senior adult",
-                "elder"
+                "senior"
             ],
-            "status": []
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -190,23 +475,29 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
-        "season": [
+        "event_id": "gen_injury_jointpain_anysenioradultsenior3",
+        "biome": [
             "any"
         ],
-        "tags": [],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "newleaf",
+            "greenleaf",
+            "leaf-fall",
+            "leaf-bare"
+        ],
         "weight": 20,
         "event_text": "m_c isn't as young as {PRONOUN/m_c/subject} used to be, and {PRONOUN/m_c/poss} aching joints are making that extremely clear.",
         "m_c": {
             "age": [
-                "senior",
-                "adolescent",
-                "young adult",
-                "adult",
                 "senior adult",
-                "elder"
+                "senior"
             ],
-            "status": []
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -220,23 +511,32 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
-        "season": [
+        "event_id": "gen_injury_jointpain_anymultiage1",
+        "biome": [
             "any"
         ],
-        "tags": [],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "newleaf",
+            "greenleaf",
+            "leaf-fall",
+            "leaf-bare"
+        ],
         "weight": 20,
         "event_text": "m_c spent the day tending to the dens, and might have worked a bit too hard - {PRONOUN/m_c/poss} joints are now quite sore.",
         "m_c": {
             "age": [
-                "senior",
                 "adolescent",
                 "young adult",
                 "adult",
                 "senior adult",
-                "elder"
+                "senior"
             ],
-            "status": [],
+            "status": [
+                "any"
+            ],
             "skill": [
                 "CAMP,2"
             ]
@@ -253,23 +553,35 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
-        "season": [
+        "event_id": "gen_injury_brokenbone_anymultiage1",
+        "biome": [
             "any"
         ],
-        "tags": [],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "newleaf",
+            "greenleaf",
+            "leaf-fall",
+            "leaf-bare"
+        ],
         "weight": 20,
         "event_text": "m_c had a bad fall while taking a walk through the territory and, once found, has to be carried back home.",
         "m_c": {
             "age": [
-                "senior",
                 "adolescent",
                 "young adult",
                 "adult",
                 "senior adult",
-                "elder"
+                "senior"
             ],
-            "status": []
+            "status": [
+                "any"
+            ],
+            "skill": [
+                "CAMP,2"
+            ]
         },
         "injury": [
             {
@@ -277,66 +589,48 @@
                     "m_c"
                 ],
                 "injuries": [
-                    "broken bone"
+                    "broken bone",
+                    "dislocated joint"
                 ],
-                "scars": [
+                "scar": [
                     "TOETRAP"
                 ]
             }
         ],
-        "history": {
-            "scar": "m_c was scarred after a bad fall.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after taking a bad fall."
-        }
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c had a bad fall while taking a walk through the territory and, once found, has to be carried back home.",
-        "m_c": {
-            "age": [
-                "senior",
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "elder"
-            ],
-            "status": []
-        },
-        "injury": [
+        "history:": [
             {
                 "cats": [
                     "m_c"
                 ],
-                "injuries": [
-                    "dislocated joint"
-                ]
+                "scar": "m_c was scarred after a bad fall.",
+                "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after taking a bad fall."
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
-        "season": [
+        "event_id": "gen_injury_tickbites_anysenioradultsenior1",
+        "biome": [
             "any"
         ],
-        "tags": [],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "newleaf",
+            "greenleaf",
+            "leaf-fall",
+            "leaf-bare"
+        ],
         "weight": 20,
         "event_text": "m_c has collected quite a lot of ticks in {PRONOUN/m_c/poss} pelt, and grumbles about the itchy bites dotted through {PRONOUN/m_c/poss} pelt.",
         "m_c": {
             "age": [
-                "senior",
-                "adolescent",
-                "young adult",
-                "adult",
                 "senior adult",
-                "elder"
+                "senior"
             ],
-            "status": []
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -350,23 +644,29 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
-        "season": [
+        "event_id": "gen_injury_tickbites_anysenioradultsenior2",
+        "biome": [
             "any"
         ],
-        "tags": [],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "newleaf",
+            "greenleaf",
+            "leaf-fall",
+            "leaf-bare"
+        ],
         "weight": 20,
         "event_text": "m_c has been yowling about {PRONOUN/m_c/poss} ticks for the better part of the day, the itchy bites maddening to {PRONOUN/m_c/object}.",
         "m_c": {
             "age": [
-                "senior",
-                "adolescent",
-                "young adult",
-                "adult",
                 "senior adult",
-                "elder"
+                "senior"
             ],
-            "status": [],
+            "status": [
+                "any"
+            ],
             "trait": [
                 "cold",
                 "fierce",
@@ -389,23 +689,29 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
-        "season": [
+        "event_id": "gen_injury_tickbites_anysenioradultsenior3",
+        "biome": [
             "any"
         ],
-        "tags": [],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "newleaf",
+            "greenleaf",
+            "leaf-fall",
+            "leaf-bare"
+        ],
         "weight": 20,
         "event_text": "m_c keeps pointedly reminding other cats that {PRONOUN/m_c/poss} ticks haven't been seen to yet, clearly uncomfortable with the itchy bites dotting {PRONOUN/m_c/poss} pelt.",
         "m_c": {
             "age": [
-                "senior",
-                "adolescent",
-                "young adult",
-                "adult",
                 "senior adult",
-                "elder"
+                "senior"
             ],
-            "status": [],
+            "status": [
+                "any"
+            ],
             "trait": [
                 "cold",
                 "fierce",
@@ -428,23 +734,29 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
-        "season": [
+        "event_id": "gen_injury_tickbites_anysenioradultsenior4",
+        "biome": [
             "any"
         ],
-        "tags": [],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "newleaf",
+            "greenleaf",
+            "leaf-fall",
+            "leaf-bare"
+        ],
         "weight": 20,
         "event_text": "m_c has been getting more and more frustrated by the number of ticks {PRONOUN/m_c/subject} {VERB/m_c/have/has}, but doesn't want to bother anyone with {PRONOUN/m_c/poss} troubles. Regardless, {PRONOUN/m_c/subject}'re found out when someone spots {PRONOUN/m_c/object} scratching at the bites.",
         "m_c": {
             "age": [
-                "senior",
-                "adolescent",
-                "young adult",
-                "adult",
                 "senior adult",
-                "elder"
+                "senior"
             ],
-            "status": [],
+            "status": [
+                "any"
+            ],
             "trait": [
                 "altruistic",
                 "calm",
@@ -468,24 +780,31 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
-        "season": [
+        "event_id": "gen_injury_clawwound_anymultitraitmultiage1",
+        "biome": [
             "any"
         ],
-        "tags": [],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "newleaf",
+            "greenleaf",
+            "leaf-fall",
+            "leaf-bare"
+        ],
         "weight": 20,
-        "event_text": "m_c tried to interject and de-escalate an argument between two Clanmates, but r_c retaliated at the interruption.  m_c limps away, fresh clawmarks scored through {PRONOUN/m_c/poss} pelt.",
+        "event_text": "m_c tried to interject and de-escalate an argument between two Clanmates, but r_c retaliated at the interruption. m_c limps away, fresh clawmarks scored through {PRONOUN/m_c/poss} pelt.",
         "m_c": {
             "age": [
-                "senior",
-                "adolescent",
                 "young adult",
                 "adult",
                 "senior adult",
-                "elder"
+                "senior"
             ],
-            "status": [],
-            "relationship_status": [],
+            "status": [
+                "any"
+            ],
             "skill": [
                 "MEDIATOR,1"
             ],
@@ -500,8 +819,15 @@
             ]
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [
+                "young adult",
+                "adult",
+                "senior adult",
+                "senior"
+            ],
+            "status": [
+                "any"
+            ],
             "trait": [
                 "bloodthirsty",
                 "bold",
@@ -523,126 +849,76 @@
                 ],
                 "injuries": [
                     "claw-wound"
-                ],
-                "scars": [
-                    "CHEEK"
                 ]
             }
         ],
-        "history": {
-            "scar": "m_c was scarred by r_c.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after r_c hurt {PRONOUN/m_c/object} for trying to stop an argument."
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "dislike",
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was on a walk when {PRONOUN/m_c/subject} saw r_c being attacked by an enemy warrior! {PRONOUN/m_c/subject/CAP} helped r_c escape, but not before gaining a few wounds.",
-        "m_c": {
-            "age": [
-                "senior",
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "elder"
-            ],
-            "status": [],
-            "relationship_status": [],
-            "trait": [
-                "altruistic",
-                "calm",
-                "compassionate",
-                "empathetic",
-                "thoughtful",
-                "daring",
-                "bold",
-                "fierce",
-                "bloodthirsty",
-                "vengeful"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
+        "history:": [
             {
                 "cats": [
                     "m_c"
                 ],
-                "injuries": [
-                    "claw-wound"
-                ],
-                "scars": [
-                    "ONE"
-                ]
+                "scar": "m_c was scarred by r_c.",
+                "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after r_c hurt {PRONOUN/m_c/object} for trying to stop an argument."
             }
         ],
-        "history": {
-            "scar": "m_c was scarred while trying to save r_c from an enemy warrior.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after trying to save r_c from an enemy warrior."
-        },
         "relationships": [
             {
                 "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
                     "m_c"
                 ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "mutual": false,
                 "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
                     "respect",
+                    "trust",
+                    "comfort",
+                    "platonic"
+                ],
+                "amount": -20
+            },
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "mutual": false,
+                "values": [
                     "dislike"
                 ],
-                "amount": -5
+                "amount": 20
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
-        "season": [
+        "event_id": "gen_injury_clawwound_anymultitraitmultiage2",
+        "biome": [
             "any"
         ],
-        "tags": [],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "newleaf",
+            "greenleaf",
+            "leaf-fall",
+            "leaf-bare"
+        ],
         "weight": 20,
         "event_text": "m_c was on a walk when {PRONOUN/m_c/subject} saw r_c being attacked by a rogue! {PRONOUN/m_c/subject/CAP} helped r_c escape, but not before gaining a few wounds.",
         "m_c": {
             "age": [
-                "senior",
-                "adolescent",
                 "young adult",
                 "adult",
                 "senior adult",
-                "elder"
+                "senior"
             ],
-            "status": [],
-            "relationship_status": [],
+            "status": [
+                "any"
+            ],
             "trait": [
                 "altruistic",
                 "calm",
@@ -657,8 +933,16 @@
             ]
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "senior"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -668,15 +952,20 @@
                 "injuries": [
                     "claw-wound"
                 ],
-                "scars": [
+                "scar": [
                     "TWO"
                 ]
             }
         ],
-        "history": {
-            "scar": "m_c was scarred while trying to save r_c from a rogue.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after trying to save r_c from a rogue."
-        },
+        "history:": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "scar": "m_c was scarred while trying to save r_c from a rogue.",
+                "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after trying to save r_c from a rogue."
+            }
+        ],
         "relationships": [
             {
                 "cats_from": [
@@ -685,36 +974,56 @@
                 "cats_to": [
                     "m_c"
                 ],
+                "mutual": false,
                 "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
                     "respect",
+                    "trust",
+                    "comfort",
+                    "platonic"
+                ],
+                "amount": 20
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
                     "dislike"
                 ],
-                "amount": -5
+                "amount": -20
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
-        "season": [
+        "event_id": "gen_injury_bitewound_anymultitraitmultiage1",
+        "biome": [
             "any"
         ],
-        "tags": [],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "newleaf",
+            "greenleaf",
+            "leaf-fall",
+            "leaf-bare"
+        ],
         "weight": 20,
         "event_text": "m_c was on a walk when {PRONOUN/m_c/subject} saw r_c being attacked by a dog! {PRONOUN/m_c/subject/CAP} helped r_c escape, but not before gaining a few wounds.",
         "m_c": {
             "age": [
-                "senior",
-                "adolescent",
                 "young adult",
                 "adult",
                 "senior adult",
-                "elder"
+                "senior"
             ],
-            "status": [],
-            "relationship_status": [],
+            "status": [
+                "any"
+            ],
             "trait": [
                 "altruistic",
                 "calm",
@@ -729,8 +1038,16 @@
             ]
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "senior"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -740,15 +1057,20 @@
                 "injuries": [
                     "bite-wound"
                 ],
-                "scars": [
+                "scar": [
                     "LEGBITE"
                 ]
             }
         ],
-        "history": {
-            "scar": "m_c was scarred while trying to save r_c from a dog.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after trying to save r_c from a dog."
-        },
+        "history:": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "scar": "m_c was scarred while trying to save r_c from a dog.",
+                "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after trying to save r_c from a dog."
+            }
+        ],
         "relationships": [
             {
                 "cats_from": [
@@ -757,604 +1079,52 @@
                 "cats_to": [
                     "m_c"
                 ],
+                "mutual": false,
                 "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
                     "respect",
+                    "trust",
+                    "comfort",
+                    "platonic"
+                ],
+                "amount": 20
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "mutual": false,
+                "values": [
                     "dislike"
                 ],
-                "amount": -5
+                "amount": -20
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
-        "season": [
+        "event_id": "gen_injury_bruises_anymultiagestatustrait1",
+        "biome": [
             "any"
         ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was grabbed and dropped by an eagle, but {PRONOUN/m_c/subject} somehow survived.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "broken bone"
-                ],
-                "scars": [
-                    "TWO"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred when an eagle grabbed {PRONOUN/m_c/object}.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after an eagle grabbed {PRONOUN/m_c/object}."
-        }
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "leaf-fall",
-            "leaf-bare"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c thought {PRONOUN/m_c/subject} {VERB/m_c/were/was} walking on a snowdrift till it gave way and {PRONOUN/m_c/subject} fell down the mountain, breaking {PRONOUN/m_c/poss} leg.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "broken bone"
-                ],
-                "scars": [
-                    "SIDE"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred when {PRONOUN/m_c/subject} fell through a snowdrift and down the mountain.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after falling down the mountain."
-        }
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "leaf-fall",
-            "leaf-bare"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c fell from a cliff and somehow survived, though not without breaking {PRONOUN/m_c/poss} leg.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "broken bone"
-                ],
-                "scars": [
-                    "MANLEG"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred when {PRONOUN/m_c/subject} fell off a cliff.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after falling off a cliff."
-        }
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was climbing a tree when {PRONOUN/m_c/subject} fell. Luckily, {PRONOUN/m_c/subject} {VERB/m_c/were/was} only bruised by the incident.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "bruises"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was pushing through some dense shrubs and felt the branches tear painfully at {PRONOUN/m_c/poss} pelt.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "torn pelt"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c survived a vicious eagle attack - with the claw marks to prove it!",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "claw-wound"
-                ],
-                "scars": [
-                    "ONE"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by an eagle.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after fighting an eagle."
-        }
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was climbing a tree and got a splinter from one of the branches.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "small cut"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was moving some branches out of the way when {PRONOUN/m_c/subject} got a splinter.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "small cut"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "leaf-fall",
-            "leaf-bare"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was out wandering the territory for a bit too long and came back with frostbite.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "frostbite"
-                ],
-                "scars": [
-                    "FROSTMITT"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by frostbite.",
-            "reg_death": "m_c died after {PRONOUN/m_c/subject} got frostbite."
-        }
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "greenleaf",
-            "newleaf",
-            "leaf-fall"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c fell into a river, and inhaled a lot of water before managing to get out. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'ve/'s} been hacking and sputtering ever since.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "water in their lungs"
-                ]
-            }
-        ],
-        "history": {
-            "reg_death": "m_c died from water-inhalation after falling in the river."
-        }
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c's tail was badly injured by falling rocks.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "mangled tail"
-                ],
-                "scars": [
-                    "MANTAIL"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by falling rocks.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after rocks fell on {PRONOUN/m_c/object}."
-        }
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was grabbed and dropped by an eagle, but {PRONOUN/m_c/subject} somehow survived.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "broken bone"
-                ],
-                "scars": [
-                    "TWO"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred when an eagle grabbed {PRONOUN/m_c/object}.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after an eagle grabbed {PRONOUN/m_c/object}."
-        }
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was running over the hills, when {PRONOUN/m_c/subject} tripped over {PRONOUN/m_c/poss} own legs and hit the ground hard.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "bruises"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "newleaf",
-            "leaf-fall"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "The ground inside the camp has turned into a muddy mess from the rain. m_c sprains {PRONOUN/m_c/poss} paw while trying to walk through the muck.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "sprain"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c trips over an unseen rabbit hole, spraining {PRONOUN/m_c/poss} paw.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "sprain"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was running over the hills, when {PRONOUN/m_c/subject} tripped over {PRONOUN/m_c/poss} own legs and hit the ground hard.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "sprain"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c is feeling extremely sore from the long distances {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} run lately.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "sore"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c survived a vicious eagle attack - with the claw marks to prove it!",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "claw-wound"
-                ],
-                "scars": [
-                    "ONE"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by an eagle.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after fighting an eagle."
-        }
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "leaf-fall",
-            "leaf-bare"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was out wandering the territory for a bit too long and came back with frostbite.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "frostbite"
-                ],
-                "scars": [
-                    "FROSTTAIL"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by frostbite.",
-            "reg_death": "m_c died after {PRONOUN/m_c/subject} got frostbite."
-        }
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "greenleaf",
-            "newleaf",
-            "leaf-fall"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c fell into a river, and inhaled a lot of water before managing to get out. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'ve/'s} been hacking and sputtering ever since.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "water in their lungs"
-                ]
-            }
-        ],
-        "history": {
-            "reg_death": "m_c died from water-inhalation after falling in the river."
-        }
-    },
-    {
-        "event_id": "gen_injury_",
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "Playfully following a butterfly outside the camp, m_c accidentally steps into a rabbit burrow severely injuring {PRONOUN/m_c/poss} leg and letting out a yelp of pain.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "trait": [
-                "childish",
-                "playful"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "mangled leg"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred when they accidentally ran their leg into a rabbit burrow.",
-            "reg_death": "m_c died from wounds caused by when they accidentally ran into a rabbit burrow."
-        }
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c overdid {PRONOUN/m_c/poss} last sparring session, and has been wincing all day. Seems {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} a bit bruised.",
         "m_c": {
             "age": [
+                "adolescent",
                 "young adult",
                 "adult",
                 "senior adult"
             ],
             "status": [
+                "apprentice",
                 "warrior",
                 "deputy",
                 "leader"
@@ -1380,20 +1150,30 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_war_clawwound_anymultitraitmultistatus2",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
+        "sub_type": [
+            "war"
+        ],
         "weight": 20,
         "event_text": "A brutal battle against o_c leaves m_c injured.",
         "m_c": {
             "age": [
+                "adolescent",
                 "young adult",
                 "adult",
                 "senior adult"
             ],
             "status": [
+                "apprentice",
                 "warrior",
                 "deputy",
                 "leader"
@@ -1424,20 +1204,30 @@
         }
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_war_catbite_anymultitraitmultistatus1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
+        "sub_type": [
+            "war"
+        ],
         "weight": 20,
         "event_text": "m_c came out worse for wear after a border skirmish with o_c.",
         "m_c": {
             "age": [
+                "adolescent",
                 "young adult",
                 "adult",
                 "senior adult"
             ],
             "status": [
+                "apprentice",
                 "warrior",
                 "deputy",
                 "leader"
@@ -1468,11 +1258,937 @@
         }
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_catbite_anyotherclanhostileany1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
+        "weight": 20,
+        "event_text": "On a border patrol near the o_c border, m_c could no longer take o_c's jeers and smirks. {PRONOUN/m_c/subject/CAP} lashed out at the first jeering cat {PRONOUN/m_c/subject} saw, although the hotheaded move wasn't smart as m_c couldn't escape the skirmish without injury.",
+        "m_c": {
+            "age": [
+                "adolescent",
+                "adult",
+                "young adult",
+                "senior adult",
+                "senior"
+            ],
+            "status": [
+                "any"
+            ],
+            "trait": [
+                "troublesome",
+                "fierce",
+                "bloodthirsty",
+                "cold",
+                "bold",
+                "daring",
+                "righteous",
+                "ambitious",
+                "confident",
+                "adventurous",
+                "shameless",
+                "vengeful",
+                "arrogant",
+                "competitive",
+                "flamboyant",
+                "rebellious"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "cat bite"
+                ]
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -5
+        }
+    },
+    {
+        "event_id": "gen_injury_clawwound_anyclankitsmultistatus1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "tags": [
+            "clan_kits"
+        ],
+        "weight": 20,
+        "event_text": "While o_c attempted a surprise attack on the c_n camp, m_c fiercely guarded the nursery. However, it didn't end with m_c unscathed, and {PRONOUN/m_c/subject} walked away with a gushing wound in {PRONOUN/m_c/poss} flank.",
+        "m_c": {
+            "age": [
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "senior adult"
+            ],
+            "status": [
+                "any"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "claw-wound"
+                ]
+            }
+        ],
+        "other_clan": {
+            "current_rep": [
+                "hostile"
+            ],
+            "changed": -5
+        }
+    },
+    {
+        "event_id": "multi_injury_anysprain2",
+        "biome": [
+            "plains",
+            "forest"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "weight": 20,
+        "event_text": "m_c trips over an unseen rabbit hole, spraining {PRONOUN/m_c/poss} paw.",
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "sprain"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "multi_injury_multikitfrostbite1",
+        "biome": [
+            "plains",
+            "forest",
+            "mountanious"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "leaf-fall",
+            "leaf-bare"
+        ],
+        "weight": 20,
+        "event_text": "m_c snuck out of camp and returned cold and shivering, frostbite nipping at {PRONOUN/m_c/poss} paws.",
+        "m_c": {
+            "age": [
+                "kitten"
+            ],
+            "status": [
+                "kitten"
+            ],
+            "trait": [
+                "daring",
+                "impulsive",
+                "inquisitive",
+                "troublesome"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "frostbite"
+                ],
+                "scars": [
+                    "FROSTMITT"
+                ]
+            }
+        ],
+        "history": {
+            "scar": "m_c was scarred as a kit by frostbite.",
+            "reg_death": "m_c died after they got frostbite sneaking out of camp."
+        }
+    },
+    {
+        "event_id": "multi_injury_anykit1",
+        "biome": [
+            "plains",
+            "forest",
+            "mountanious"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "weight": 20,
+        "event_text": "m_c was grabbed by an eagle, but luckily r_c saves {PRONOUN/m_c/object}! The kit is still left injured from the ordeal.",
+        "m_c": {
+            "age": [
+                "kitten"
+            ],
+            "status": [
+                "kitten"
+            ]
+        },
+        "r_c": {
+            "age": [
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "senior"
+            ],
+            "status": [
+                "apprentice",
+                "mediator apprentice",
+                "medicine cat apprentice",
+                "warrior",
+                "mediator",
+                "medicine cat",
+                "deputy",
+                "leader",
+                "elder"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "claw-wound"
+                ],
+                "scars": [
+                    "TWO"
+                ]
+            }
+        ],
+        "history": {
+            "scar": "m_c was scarred as a kit, when an eagle tried to carry {PRONOUN/m_c/object} off.",
+            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after an eagle tried to carry {PRONOUN/m_c/object} off."
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "platonic",
+                    "comfort",
+                    "trust",
+                    "respect"
+                ],
+                "amount": 15
+            }
+        ]
+    },
+    {
+        "event_id": "multi_injury_anykit1",
+        "biome": [
+            "plains",
+            "forest",
+            "mountanious"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "weight": 20,
+        "event_text": "m_c was grabbed by a hawk, but luckily r_c saves {PRONOUN/m_c/object}! The kit is still left injured from the ordeal.",
+        "m_c": {
+            "age": [
+                "kitten"
+            ],
+            "status": [
+                "kitten"
+            ]
+        },
+        "r_c": {
+            "age": [
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "senior"
+            ],
+            "status": [
+                "apprentice",
+                "mediator apprentice",
+                "medicine cat apprentice",
+                "warrior",
+                "mediator",
+                "medicine cat",
+                "deputy",
+                "leader",
+                "elder"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "claw-wound"
+                ],
+                "scars": [
+                    "TWO"
+                ]
+            }
+        ],
+        "history": {
+            "scar": "m_c was scarred as a kit, when an eagle tried to carry {PRONOUN/m_c/object} off.",
+            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after an eagle tried to carry {PRONOUN/m_c/object} off."
+        },
+        "relationships": [
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "mutual": false,
+                "values": [
+                    "platonic",
+                    "comfort",
+                    "trust",
+                    "respect"
+                ],
+                "amount": 15
+            }
+        ]
+    },
+    {
+        "event_id": "multi_injury_multiwaterinthelungs1",
+        "biome": [
+            "plains",
+            "forest",
+            "mountanious"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "greenleaf",
+            "newleaf",
+            "leaf-fall"
+        ],
+        "weight": 20,
+        "event_text": "m_c fell into a river, and inhaled a lot of water before managing to get out. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'ve/'s} been hacking and sputtering ever since.",
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "water in their lungs"
+                ]
+            }
+        ],
+        "history": {
+            "reg_death": "m_c died from water-inhalation after falling in the river."
+        }
+    },
+    {
+        "event_id": "gen_injury_multifrostbite1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "leaf-fall",
+            "leaf-bare"
+        ],
+        "weight": 20,
+        "event_text": "m_c was out wandering the territory for a bit too long and came back with frostbite.",
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "frostbite"
+                ],
+                "scars": [
+                    "FROSTTAIL"
+                ]
+            }
+        ],
+        "history": {
+            "scar": "m_c was scarred by frostbite.",
+            "reg_death": "m_c died after {PRONOUN/m_c/subject} got frostbite."
+        }
+    },
+    {
+        "event_id": "multi_injury_leafbarebrokenbone1",
+        "biome": [
+            "plains",
+            "mountainous",
+            "forest"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "leaf-bare"
+        ],
+        "weight": 20,
+        "event_text": "m_c went out for a walk, but slipped on the ice and broke a bone.",
+        "m_c": {
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "broken bone"
+                ],
+                "scars": [
+                    "TOETRAP"
+                ]
+            }
+        ],
+        "history": {
+            "scar": "m_c was scarred after slipping on ice.",
+            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after slipping on ice."
+        }
+    },
+    {
+        "event_id": "multi_injury_anybrokenbone1",
+        "biome": [
+            "plains",
+            "mountainous"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "weight": 20,
+        "event_text": "m_c was grabbed and dropped by an eagle, but {PRONOUN/m_c/subject} somehow survived.",
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "broken bone"
+                ],
+                "scars": [
+                    "TWO"
+                ]
+            }
+        ],
+        "history": {
+            "scar": "m_c was scarred when an eagle grabbed {PRONOUN/m_c/object}.",
+            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after an eagle grabbed {PRONOUN/m_c/object}."
+        }
+    },
+    {
+        "event_id": "multi_injury_anysmallcut1",
+        "biome": [
+            "beach",
+            "mountainous",
+            "forest"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "weight": 20,
+        "event_text": "m_c was climbing a tree and got a splinter from one of the branches.",
+        "m_c": {
+            "age": [
+                "any"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "small cut"
+                ]
+            }
+        ],
+        "history": {
+            "scar": "m_c was scarred after slipping on ice.",
+            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after slipping on ice."
+        }
+    },
+    {
+        "event_id": "multi_injury_anybruises1",
+        "biome": [
+            "beach",
+            "mountainous",
+            "forest"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "weight": 20,
+        "event_text": "m_c was climbing a tree when {PRONOUN/m_c/subject} fell. Luckily, {PRONOUN/m_c/subject} {VERB/m_c/were/was} only bruised by the incident.",
+        "m_c": {
+            "age": [
+                "any"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "small cut"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "multi_injury_anybruises1",
+        "biome": [
+            "beach",
+            "forest"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "weight": 20,
+        "event_text": "m_c couldn't help but try to show off by climbing the tallest tree {PRONOUN/m_c/subject} could find. {PRONOUN/m_c/poss/CAP} plan backfired when {PRONOUN/m_c/subject} fell out of the tree.",
+        "m_c": {
+            "age": [
+                "adolescent"
+            ],
+            "status": [
+                "apprentice"
+            ],
+            "trait": [
+                "adventurous",
+                "ambitious",
+                "bold",
+                "childish",
+                "confident",
+                "daring",
+                "playful",
+                "troublesome"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "broken bone"
+                ],
+                "scars": [
+                    "SIDE"
+                ]
+            }
+        ],
+        "history": {
+            "scar": "m_c was scarred after falling from a tall tree.",
+            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after falling from a tall tree."
+        }
+    },
+    {
+        "event_id": "gen_injury_sore_anymultiage1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "weight": 20,
+        "event_text": "m_c had a bad fall while taking a walk through the territory, and comes back to camp quite sore.",
+        "m_c": {
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult"
+            ],
+            "status": [
+                "any"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "sore"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_",
+        "season": [
+            "leaf-fall",
+            "leaf-bare"
+        ],
+        "weight": 20,
+        "event_text": "m_c thought {PRONOUN/m_c/subject} {VERB/m_c/were/was} walking on a snowdrift till it gave way and {PRONOUN/m_c/subject} fell down the mountain, breaking {PRONOUN/m_c/poss} leg.",
+        "m_c": {
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "broken bone"
+                ],
+                "scars": [
+                    "SIDE"
+                ]
+            }
+        ],
+        "history": {
+            "scar": "m_c was scarred when {PRONOUN/m_c/subject} fell through a snowdrift and down the mountain.",
+            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after falling down the mountain."
+        }
+    },
+    {
+        "event_id": "gen_injury_",
+        "season": [
+            "leaf-fall",
+            "leaf-bare"
+        ],
+        "weight": 20,
+        "event_text": "m_c fell from a cliff and somehow survived, though not without breaking {PRONOUN/m_c/poss} leg.",
+        "m_c": {
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "broken bone"
+                ],
+                "scars": [
+                    "MANLEG"
+                ]
+            }
+        ],
+        "history": {
+            "scar": "m_c was scarred when {PRONOUN/m_c/subject} fell off a cliff.",
+            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after falling off a cliff."
+        }
+    },
+    {
+        "event_id": "multi_injury_clawwound_any1",
+        "biome": [
+            "plains",
+            "mountainious"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "weight": 0,
+        "event_text": "m_c survived a vicious eagle attack - with the claw marks to prove it!",
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "claw-wound"
+                ],
+                "scars": [
+                    "ONE"
+                ]
+            }
+        ],
+        "history": {
+            "scar": "m_c was scarred by an eagle.",
+            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after fighting an eagle."
+        }
+    },
+    {
+        "event_id": "gen_injury_smallcut_any2",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "weight": 20,
+        "event_text": "m_c was moving some branches out of the way when {PRONOUN/m_c/subject} got a splinter.",
+        "m_c": {
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult"
+            ],
+            "status": [
+                "any"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "small cut"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_bruises_anymultisage3",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "weight": 20,
+        "event_text": "m_c was running over the hills, when {PRONOUN/m_c/subject} tripped over {PRONOUN/m_c/poss} own legs and hit the ground hard.",
+        "m_c": {
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "bruises"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_sprain_anymultiage6",
+        "season": [
+            "newleaf",
+            "leaf-fall"
+        ],
+        "weight": 20,
+        "event_text": "The ground inside the camp has turned into a muddy mess from the rain. m_c sprains {PRONOUN/m_c/poss} paw while trying to walk through the muck.",
+        "m_c": {
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult"
+            ],
+            "status": [
+                "any"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "sprain"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "weight": 20,
+        "event_text": "m_c is feeling extremely sore from the long distances {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} run lately.",
+        "m_c": {
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "sore"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_mangledleg_anymultiagemultitrait1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "weight": 20,
+        "event_text": "Playfully following a butterfly outside the camp, m_c accidentally steps into a rabbit burrow severely injuring {PRONOUN/m_c/poss} leg and letting out a yelp of pain.",
+        "m_c": {
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ],
+            "trait": [
+                "childish",
+                "playful"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "mangled leg"
+                ]
+            }
+        ],
+        "history": {
+            "scar": "m_c was scarred when they accidentally ran their leg into a rabbit burrow.",
+            "reg_death": "m_c died from wounds caused by when they accidentally ran into a rabbit burrow."
+        }
+    },
+    {
+        "event_id": "gen_injury_bruises_anymultiagestatustraitfighter1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
         "weight": 20,
         "event_text": "m_c fought a rogue, but was barely even hurt! {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} a bit bruised, but bruises are better than clawmarks.",
         "m_c": {
@@ -1511,11 +2227,16 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_bruises_anymultiagestatustraitfighter2",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c fought a fox, but was barely even hurt! {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} a bit bruised, but bruises are better than clawmarks.",
         "m_c": {
@@ -1554,11 +2275,16 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_bruises_anymultiagestatustraitfighter3",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c fought a dog, but was barely even hurt! {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} a bit bruised, but bruises are better than clawmarks.",
         "m_c": {
@@ -1597,11 +2323,16 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_bruises_anymultiagestatustraitfighter4",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c saved r_c from an enemy warrior, and was barely even hurt! {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} a bit bruised, but bruises are better than clawmarks.",
         "m_c": {
@@ -1615,7 +2346,6 @@
                 "deputy",
                 "leader"
             ],
-            "relationship_status": [],
             "skill": [
                 "FIGHTER,1"
             ],
@@ -1636,8 +2366,16 @@
             ]
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -1668,11 +2406,16 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_bruises_anymultiagestatustraitfighter5",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c saved r_c from a dog, and was barely even hurt! {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} a bit bruised, but bruises are better than clawmarks.",
         "m_c": {
@@ -1686,7 +2429,6 @@
                 "deputy",
                 "leader"
             ],
-            "relationship_status": [],
             "skill": [
                 "FIGHTER,1"
             ],
@@ -1707,8 +2449,17 @@
             ]
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -1739,11 +2490,16 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_scrapes_anymultiagestatustrait1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c overdid {PRONOUN/m_c/poss} last sparring session, and has been wincing all day. Seems {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} a bit scraped up.",
         "m_c": {
@@ -1778,11 +2534,16 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_scrapes_anymultiagestatustraitfighter1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c fought a rogue, but was barely even hurt! {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} a bit scraped up, but a few scrapes are better than clawmarks.",
         "m_c": {
@@ -1821,11 +2582,16 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_scrapes_anymultiagestatustraitfighter2",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c fought a fox, but was barely even hurt! {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} a bit scraped up, but a few scrapes are better than clawmarks.",
         "m_c": {
@@ -1864,11 +2630,16 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_scrapes_anymultiagestatustraitfighter3",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c saved r_c from a fox, and was barely even hurt! {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} a bit scraped up, but a few scrapes are better than clawmarks.",
         "m_c": {
@@ -1882,7 +2653,6 @@
                 "deputy",
                 "leader"
             ],
-            "relationship_status": [],
             "skill": [
                 "FIGHTER,1"
             ],
@@ -1903,8 +2673,17 @@
             ]
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -1935,11 +2714,16 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_sprain_anymultiagestatustrait1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c overdid {PRONOUN/m_c/poss} last sparring session and sprained a paw.",
         "m_c": {
@@ -1974,20 +2758,27 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_bitewound_anymultiagestatustraitnotfighter1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c fought a dog and got hurt.",
         "m_c": {
             "age": [
+                "adolescent",
                 "young adult",
                 "adult",
                 "senior adult"
             ],
             "status": [
+                "apprentice",
                 "warrior",
                 "deputy",
                 "leader"
@@ -2024,25 +2815,31 @@
         }
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_bitewound_anymultiagestatustraitnotfighterothercat1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c saved r_c from a fox, but was hurt.",
         "m_c": {
             "age": [
+                "adolescent",
                 "young adult",
                 "adult",
                 "senior adult"
             ],
             "status": [
+                "apprentice",
                 "warrior",
                 "deputy",
                 "leader"
             ],
-            "relationship_status": [],
             "not_skill": [
                 "FIGHTER,2"
             ],
@@ -2063,8 +2860,17 @@
             ]
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -2102,13 +2908,18 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_bitewound_anymultiagestatustraitnotfighterothercatleader1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
-        "event_text": "m_c was hurt while protecting the leader from a fox.",
+        "event_text": "m_c was hurt while protecting r_c, the leader, from a fox.",
         "m_c": {
             "age": [
                 "young adult",
@@ -2120,7 +2931,6 @@
                 "deputy",
                 "leader"
             ],
-            "relationship_status": [],
             "not_skill": [
                 "FIGHTER,2"
             ],
@@ -2141,8 +2951,12 @@
             ]
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "any"
+            ],
+            "status": [
+                "leader"
+            ]
         },
         "injury": [
             {
@@ -2180,20 +2994,27 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_catbite_anymultiagestatustraitnotfighter1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c fought a rogue and got hurt.",
         "m_c": {
             "age": [
+                "adolescent",
                 "young adult",
                 "adult",
                 "senior adult"
             ],
             "status": [
+                "apprentice",
                 "warrior",
                 "deputy",
                 "leader"
@@ -2230,241 +3051,27 @@
         }
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_brokenbone_anymultiagestatustraitnotfighter1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was wounded during a harsh training exercise lead by r_c.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ],
-            "relationship_status": [],
-            "not_skill": [
-                "FIGHTER,2"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": [],
-            "trait": [
-                "bloodthirsty",
-                "daring",
-                "strict",
-                "vengeful"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "cat bite"
-                ],
-                "scars": [
-                    "CATBITE"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred during a harsh training exercise with r_c.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after a harsh training exercise with r_c."
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "dislike",
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was hurt by o_c warriors after being ordered by r_c to go over the border.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ],
-            "relationship_status": [],
-            "not_skill": [
-                "FIGHTER,2"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": [],
-            "trait": [
-                "bloodthirsty",
-                "daring",
-                "bold",
-                "righteous",
-                "strict",
-                "vengeful"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "cat bite"
-                ],
-                "scars": [
-                    "CATBITE"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by o_c warriors, after being ordered to go over the border by r_c.",
-            "reg_death": "m_c died from wounds caused by o_c warriors, after being ordered to go over the border by r_c.."
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "dislike",
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
-                "amount": -5
-            }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile",
-                "neutral"
-            ],
-            "changed": -5
-        }
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was injured after a fight with a Clanmate that r_c encouraged.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ],
-            "relationship_status": [],
-            "not_skill": [
-                "FIGHTER,2"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": [],
-            "trait": [
-                "bloodthirsty",
-                "vengeful",
-                "ambitiuos",
-                "bold",
-                "fierce",
-                "insecure"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "cat bite"
-                ],
-                "scars": [
-                    "CATBITE"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by a Clanmate that r_c encouraged {PRONOUN/m_c/object} to fight.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after a fight with a Clanmate that r_c encouraged."
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "dislike",
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c fought a big dog and was badly injured.",
         "m_c": {
             "age": [
+                "adolescent",
                 "young adult",
                 "adult",
                 "senior adult"
             ],
             "status": [
+                "apprentice",
                 "warrior",
                 "deputy",
                 "leader"
@@ -2501,25 +3108,31 @@
         }
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_brokenbone_anymultiagestatustraitnotfighterothercat1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c saved r_c from a big dog, but was badly injured.",
         "m_c": {
             "age": [
+                "adolescent",
                 "young adult",
                 "adult",
                 "senior adult"
             ],
             "status": [
+                "apprentice",
                 "warrior",
                 "deputy",
                 "leader"
             ],
-            "relationship_status": [],
             "not_skill": [
                 "FIGHTER,3"
             ],
@@ -2540,8 +3153,18 @@
             ]
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult"
+            ],
+            "status": [
+                "apprentice",
+                "warrior",
+                "deputy",
+                "leader"
+            ]
         },
         "injury": [
             {
@@ -2572,28 +3195,34 @@
                     "platonic",
                     "comfort",
                     "trust",
-                    "respect",
-                    "dislike"
+                    "respect"
                 ],
-                "amount": -5
+                "amount": 10
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_clawwound_anymultiagestatustraitnotfighter1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c fought a hawk and got hurt.",
         "m_c": {
             "age": [
+                "adolescent",
                 "young adult",
                 "adult",
                 "senior adult"
             ],
             "status": [
+                "apprentice",
                 "warrior",
                 "deputy",
                 "leader"
@@ -2630,25 +3259,31 @@
         }
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_clawwound_anymultiagestatustraitnotfighterothercat1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c saved r_c from a hawk, but was hurt.",
         "m_c": {
             "age": [
+                "adolescent",
                 "young adult",
                 "adult",
                 "senior adult"
             ],
             "status": [
+                "apprentice",
                 "warrior",
                 "deputy",
                 "leader"
             ],
-            "relationship_status": [],
             "not_skill": [
                 "FIGHTER,2"
             ],
@@ -2669,8 +3304,12 @@
             ]
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "any"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -2708,13 +3347,18 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_clawwound_anymultiagemultistatusnotfightermultitraitothercatleader1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
-        "event_text": "m_c was hurt while protecting the leader from a rogue.",
+        "event_text": "m_c was hurt while protecting the leader, r_c, from a rogue.",
         "m_c": {
             "age": [
                 "young adult",
@@ -2723,10 +3367,8 @@
             ],
             "status": [
                 "warrior",
-                "deputy",
-                "leader"
+                "deputy"
             ],
-            "relationship_status": [],
             "not_skill": [
                 "FIGHTER,2"
             ],
@@ -2747,8 +3389,17 @@
             ]
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "leader"
+            ]
         },
         "injury": [
             {
@@ -2779,19 +3430,35 @@
                     "platonic",
                     "comfort",
                     "trust",
-                    "respect",
+                    "respect"
+                ],
+                "amount": 10
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
                     "dislike"
                 ],
-                "amount": -5
+                "amount": -10
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_clawwoundcatbite_anymultiagenotfighterothercatmultitrait3",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c was wounded during a harsh training exercise lead by r_c.",
         "m_c": {
@@ -2801,18 +3468,24 @@
                 "senior adult"
             ],
             "status": [
-                "warrior",
-                "deputy",
-                "leader"
+                "warrior"
             ],
-            "relationship_status": [],
             "not_skill": [
                 "FIGHTER,2"
             ]
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult"
+            ],
+            "status": [
+                "deputy",
+                "leader"
+            ],
             "trait": [
                 "bloodthirsty",
                 "daring",
@@ -2826,10 +3499,12 @@
                     "m_c"
                 ],
                 "injuries": [
-                    "claw-wound"
+                    "claw-wound",
+                    "cat bite"
                 ],
                 "scars": [
-                    "BELLY"
+                    "BELLY",
+                    "CATBITE"
                 ]
             }
         ],
@@ -2846,22 +3521,38 @@
                     "r_c"
                 ],
                 "values": [
-                    "dislike",
                     "platonic",
                     "comfort",
                     "trust",
                     "respect"
                 ],
                 "amount": -5
+            },
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": 5
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_clawwoundcatbite_anymultiagenotfighterothercatmultitrait2",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c was hurt by o_c warriors after being ordered by r_c to go over the border.",
         "m_c": {
@@ -2875,14 +3566,22 @@
                 "deputy",
                 "leader"
             ],
-            "relationship_status": [],
             "not_skill": [
                 "FIGHTER,2"
             ]
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ],
             "trait": [
                 "bloodthirsty",
                 "daring",
@@ -2898,10 +3597,12 @@
                     "m_c"
                 ],
                 "injuries": [
-                    "claw-wound"
+                    "claw-wound",
+                    "cat bite"
                 ],
                 "scars": [
-                    "CHEEK"
+                    "CHEEK",
+                    "CATBITE"
                 ]
             }
         ],
@@ -2918,13 +3619,24 @@
                     "r_c"
                 ],
                 "values": [
-                    "dislike",
                     "platonic",
                     "comfort",
                     "trust",
                     "respect"
                 ],
-                "amount": -5
+                "amount": -10
+            },
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": 10
             }
         ],
         "other_clan": {
@@ -2936,11 +3648,16 @@
         }
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_clawwoundcatbite_anymultiagenotfighterothercatmultitrait1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c was injured after a fight with a Clanmate that r_c encouraged.",
         "m_c": {
@@ -2950,25 +3667,30 @@
                 "senior adult"
             ],
             "status": [
+                "any"
+            ],
+            "not_skill": [
+                "FIGHTER,3"
+            ]
+        },
+        "r_c": {
+            "age": [
+                "any"
+            ],
+            "status": [
                 "warrior",
                 "deputy",
                 "leader"
             ],
-            "relationship_status": [],
-            "not_skill": [
-                "FIGHTER,2"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": [],
             "trait": [
+                "ambitious",
                 "bloodthirsty",
-                "vengeful",
-                "ambitiuos",
                 "bold",
+                "cold",
+                "daring",
                 "fierce",
-                "insecure"
+                "strict",
+                "vengeful"
             ]
         },
         "injury": [
@@ -2977,10 +3699,12 @@
                     "m_c"
                 ],
                 "injuries": [
-                    "claw-wound"
+                    "claw-wound",
+                    "cat bite"
                 ],
                 "scars": [
-                    "ONE"
+                    "ONE",
+                    "CATBITE"
                 ]
             }
         ],
@@ -2997,22 +3721,38 @@
                     "r_c"
                 ],
                 "values": [
-                    "dislike",
                     "platonic",
                     "comfort",
                     "trust",
                     "respect"
                 ],
-                "amount": -5
+                "amount": -10
+            },
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": 10
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_mangledleg_anyapprenticenotfighterothercatmultistatusmultitrait2",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c's tail was badly hurt by a fox while {PRONOUN/m_c/subject} {VERB/m_c/were/was} trying to follow r_c's orders.",
         "m_c": {
@@ -3022,18 +3762,21 @@
                 "senior adult"
             ],
             "status": [
+                "any"
+            ],
+            "not_skill": [
+                "FIGHTER,3"
+            ]
+        },
+        "r_c": {
+            "age": [
+                "any"
+            ],
+            "status": [
                 "warrior",
                 "deputy",
                 "leader"
             ],
-            "relationship_status": [],
-            "not_skill": [
-                "FIGHTER,2"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": [],
             "trait": [
                 "ambitious",
                 "bloodthirsty",
@@ -3041,7 +3784,6 @@
                 "cold",
                 "daring",
                 "fierce",
-                "righteous",
                 "strict",
                 "vengeful"
             ]
@@ -3072,22 +3814,38 @@
                     "r_c"
                 ],
                 "values": [
-                    "dislike",
                     "platonic",
                     "comfort",
                     "trust",
                     "respect"
                 ],
-                "amount": -5
+                "amount": -10
+            },
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": 10
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_mangledleg_anyapprenticenotfighterothercatmultistatusmultitrait1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c's leg was badly injured after r_c forced {PRONOUN/m_c/object} to fight a big dog.",
         "m_c": {
@@ -3097,18 +3855,21 @@
                 "senior adult"
             ],
             "status": [
-                "warrior",
-                "deputy",
-                "leader"
+                "any"
             ],
-            "relationship_status": [],
             "not_skill": [
                 "FIGHTER,3"
             ]
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [
+                "any"
+            ],
+            "status": [
+                "warrior",
+                "deputy",
+                "leader"
+            ],
             "trait": [
                 "ambitious",
                 "bloodthirsty",
@@ -3146,22 +3907,38 @@
                     "r_c"
                 ],
                 "values": [
-                    "dislike",
                     "platonic",
                     "comfort",
                     "trust",
                     "respect"
                 ],
-                "amount": -5
+                "amount": -10
+            },
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": 10
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_damagedeyes_anyapprentice1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c mistook a hare for a rabbit while hunting and {PRONOUN/m_c/poss} eyes were scratched, a valuable lesson learnt.",
         "m_c": {
@@ -3191,91 +3968,19 @@
         }
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_sore_war_anyapprentice2",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "A brutal battle against o_c leaves m_c injured.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "claw-wound"
-                ],
-                "scars": [
-                    "SIDE"
-                ]
-            }
+        "sub_type": [
+            "war"
         ],
-        "history": {
-            "scar": "m_c was scarred in a fight against o_c.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after a battle with o_c."
-        },
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": -5
-        }
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c came out worse for wear after a border skirmish with o_c.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "cat bite"
-                ],
-                "scars": [
-                    "SIDE"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred in a fight against o_c.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after a battle with o_c."
-        },
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": -5
-        }
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
         "weight": 20,
         "event_text": "Heightened battle training has left m_c sore and tired.",
         "m_c": {
@@ -3295,20 +4000,22 @@
                     "sore"
                 ]
             }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": 0
-        }
+        ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_bruises_war_anyapprentice1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
+        "sub_type": [
+            "war"
+        ],
         "weight": 20,
         "event_text": "A harsh sparring session has left m_c bruised. {PRONOUN/m_c/subject/CAP} {VERB/m_c/worry/worries} that {PRONOUN/m_c/subject} will do badly in a real fight against o_c.",
         "m_c": {
@@ -3328,20 +4035,22 @@
                     "bruises"
                 ]
             }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": 0
-        }
+        ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_mangledtail_war_anyapprenticehostile1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
+        "sub_type": [
+            "war"
+        ],
         "weight": 20,
         "event_text": "A horrible battle occurred between c_n and o_c patrols after the two patrols traded insults at the border. m_c is left badly injured.",
         "m_c": {
@@ -3373,15 +4082,20 @@
             "current_rep": [
                 "hostile"
             ],
-            "changed": 0
+            "changed": -10
         }
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_catbite_anyapprenticemultitraitappmentor4",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c was injured recklessly fighting a rogue that {PRONOUN/m_c/poss} mentor, r_c, encouraged {PRONOUN/m_c/object} to attack.",
         "m_c": {
@@ -3396,8 +4110,17 @@
             ]
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ],
             "skill": [
                 "FIGHTER,1"
             ],
@@ -3442,22 +4165,38 @@
                     "r_c"
                 ],
                 "values": [
-                    "dislike",
                     "platonic",
                     "comfort",
                     "trust",
                     "respect"
                 ],
                 "amount": -5
+            },
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": 5
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_catbite_anyapprenticemultitraitappmentor3",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c was injured recklessly fighting an enemy warrior that {PRONOUN/m_c/poss} mentor, r_c, encouraged {PRONOUN/m_c/object} to attack.",
         "m_c": {
@@ -3472,8 +4211,12 @@
             ]
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [
+                "any"
+            ],
+            "status": [
+                "any"
+            ],
             "skill": [
                 "FIGHTER,1"
             ],
@@ -3518,22 +4261,38 @@
                     "r_c"
                 ],
                 "values": [
-                    "dislike",
                     "platonic",
                     "comfort",
                     "trust",
                     "respect"
                 ],
                 "amount": -5
+            },
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": 5
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_bitewound_anyapprenticeappmentorfightermultitrait2",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c was injured recklessly fighting a dog that {PRONOUN/m_c/poss} mentor, r_c, encouraged {PRONOUN/m_c/object} to attack.",
         "m_c": {
@@ -3548,8 +4307,12 @@
             ]
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [
+                "any"
+            ],
+            "status": [
+                "any"
+            ],
             "skill": [
                 "FIGHTER,1"
             ],
@@ -3594,22 +4357,38 @@
                     "r_c"
                 ],
                 "values": [
-                    "dislike",
                     "platonic",
                     "comfort",
                     "trust",
                     "respect"
                 ],
                 "amount": -5
+            },
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": 5
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_bitewound_anyapprenticeappmentorfightermultitrait1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c was injured recklessly fighting a fox that {PRONOUN/m_c/poss} mentor, r_c, encouraged {PRONOUN/m_c/object} to attack.",
         "m_c": {
@@ -3624,8 +4403,12 @@
             ]
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [
+                "any"
+            ],
+            "status": [
+                "any"
+            ],
             "skill": [
                 "FIGHTER,1"
             ],
@@ -3670,496 +4453,40 @@
                     "r_c"
                 ],
                 "values": [
-                    "dislike",
                     "platonic",
                     "comfort",
                     "trust",
                     "respect"
                 ],
                 "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c fought a dog and got hurt.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "trait": [
-                "adventurous",
-                "ambitious",
-                "bloodthirsty",
-                "bold",
-                "daring",
-                "fierce",
-                "vengeful"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "bite-wound"
-                ],
-                "scars": [
-                    "NECKBITE"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by a dog.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after fighting a dog."
-        }
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c saved r_c from a fox, but was hurt.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": [],
-            "trait": [
-                "altruistic",
-                "compassionate",
-                "loving",
-                "empathetic",
-                "responsible",
-                "loyal",
-                "adventurous",
-                "ambitious",
-                "bloodthirsty",
-                "bold",
-                "daring",
-                "fierce",
-                "vengeful"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "bite-wound"
-                ],
-                "scars": [
-                    "LEGBITE"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by a fox while rescuing r_c.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after saving r_c from a fox."
-        },
-        "relationships": [
+            },
             {
                 "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
                     "m_c"
                 ],
+                "cats_to": [
+                    "r_c"
+                ],
                 "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
+                    "dislike"
                 ],
                 "amount": 5
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_catbite_anyapprenticemultitraitappmentor1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
-        "event_text": "m_c was hurt by r_c for not defending the territory well enough.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": [
-                "app/mentor"
-            ],
-            "trait": [
-                "insecure",
-                "nervous",
-                "careful",
-                "loving"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": [],
-            "trait": [
-                "bloodthirsty",
-                "cold",
-                "fierce",
-                "righteous",
-                "strict",
-                "vengeful",
-                "loyal"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "cat bite"
-                ],
-                "scars": [
-                    "CATBITE"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by {PRONOUN/m_c/poss} mentor, r_c, for failing to defend the territory well enough.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after {PRONOUN/m_c/poss} mentor hurt {PRONOUN/m_c/object} for failing to defend the territory well enough."
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "dislike",
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was hurt by {PRONOUN/m_c/poss} mentor, r_c, as a punishment for accidentally wandering over the border.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": [
-                "app/mentor"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": [],
-            "trait": [
-                "bloodthirsty",
-                "cold",
-                "fierce",
-                "righteous",
-                "strict",
-                "vengeful",
-                "loyal"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "cat bite"
-                ],
-                "scars": [
-                    "CATBITE"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by {PRONOUN/m_c/poss} mentor, r_c, for accidentally crossing the border.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after {PRONOUN/m_c/poss} mentor hurt {PRONOUN/m_c/object} for accidentally crossing the border."
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "dislike",
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was hurt by {PRONOUN/m_c/poss} mentor, r_c, as a punishment for messing with a Twoleg object.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": [
-                "app/mentor"
-            ],
-            "trait": [
-                "troublesome",
-                "childish",
-                "playful",
-                "adventurous"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": [],
-            "trait": [
-                "bloodthirsty",
-                "cold",
-                "fierce",
-                "righteous",
-                "strict",
-                "vengeful",
-                "loyal"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "cat bite"
-                ],
-                "scars": [
-                    "CATBITE"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by {PRONOUN/m_c/poss} mentor, r_c, for messing with a Twoleg object.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after {PRONOUN/m_c/poss} mentor hurt {PRONOUN/m_c/object} for messing with a Twoleg object."
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "dislike",
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was hurt by {PRONOUN/m_c/poss} mentor, r_c, as a punishment for disobeying {PRONOUN/r_c/object}.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": [
-                "app/mentor"
-            ],
-            "trait": [
-                "troublesome",
-                "childish",
-                "playful"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": [],
-            "trait": [
-                "bloodthirsty",
-                "cold",
-                "fierce",
-                "righteous",
-                "strict",
-                "vengeful"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "cat bite"
-                ],
-                "scars": [
-                    "CATBITE"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by {PRONOUN/m_c/poss} mentor, r_c, for disobeying {PRONOUN/r_c/object}.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after {PRONOUN/m_c/poss} mentor hurt {PRONOUN/m_c/object} for disobeying {PRONOUN/r_c/object}."
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "dislike",
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c fought with {PRONOUN/m_c/poss} mentor, r_c, and was injured.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": [
-                "app/mentor"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": [],
-            "skill": [
-                "FIGHTER,1"
-            ],
-            "trait": [
-                "bloodthirsty",
-                "cold",
-                "fierce",
-                "righteous",
-                "strict",
-                "vengeful"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "cat bite"
-                ],
-                "scars": [
-                    "CATBITE"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred after fighting with {PRONOUN/m_c/poss} mentor, r_c.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after fighting with {PRONOUN/m_c/poss} mentor."
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "dislike",
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c could not handle {PRONOUN/m_c/poss} mentor's harsh training, and was injured as a result.",
+        "event_text": "m_c could not handle r_c's harsh training, and was injured as a result.",
         "m_c": {
             "age": [
                 "adolescent"
@@ -4184,8 +4511,17 @@
             ]
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ],
             "trait": [
                 "bloodthirsty",
                 "cold",
@@ -4232,13 +4568,18 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_bruises_anyapprenticemultitraitappmentor1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
-        "event_text": "m_c fought a rogue and got hurt.",
+        "event_text": "m_c trained extra hard to impress {PRONOUN/m_c/poss} mentor, r_c, but was a bit too rough with {PRONOUN/m_c/poss} body, and has the bruises to show it.",
         "m_c": {
             "age": [
                 "adolescent"
@@ -4246,54 +4587,22 @@
             "status": [
                 "apprentice"
             ],
-            "trait": [
-                "adventurous",
-                "ambitious",
-                "bloodthirsty",
-                "bold",
-                "daring",
-                "fierce",
-                "vengeful"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "cat bite"
-                ],
-                "scars": [
-                    "CATBITE"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by a rogue.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after fighting a rogue."
-        }
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c trained extra hard to impress {PRONOUN/m_c/poss} mentor, but was a bit too rough with {PRONOUN/m_c/poss} body, and has the bruises to show it.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
+            "relationship_status": [
+                "app/mentor"
             ],
             "trait": [
                 "ambitious",
                 "daring",
                 "bold",
                 "loyal"
+            ]
+        },
+        "r_c": {
+            "age": [
+                "any"
+            ],
+            "status": [
+                "any"
             ]
         },
         "injury": [
@@ -4308,11 +4617,16 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_bruises_anyapprentice2",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c took a tumble off a rock while practicing {PRONOUN/m_c/poss} battle moves. {PRONOUN/m_c/subject/CAP}'ll be a bit tender for the next few days.",
         "m_c": {
@@ -4335,11 +4649,16 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_bruises_anyapprentice1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c was practicing {PRONOUN/m_c/poss} hunting pounce when {PRONOUN/m_c/subject} pounced right into a rock! Ow! {PRONOUN/m_c/subject/CAP} might be sore for a while.",
         "m_c": {
@@ -4362,11 +4681,16 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_bruises_anyapprenticemultitrait1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c overdid {PRONOUN/m_c/poss} last battle training session, and has been wincing all day. Seems {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} a bit bruised.",
         "m_c": {
@@ -4397,11 +4721,16 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_scrapes_anyapprenticemultitrait1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c overdid {PRONOUN/m_c/poss} last battle training session, and has been wincing all day. Seems {PRONOUN/m_c/subject}{VERB/m_c/'re/'s} a bit scraped up.",
         "m_c": {
@@ -4432,13 +4761,18 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_sprain_anyapprenticemultitraitappmentor1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
-        "event_text": "m_c trained extra hard to impress {PRONOUN/m_c/poss} mentor, but twisted {PRONOUN/m_c/poss} paw at an awkward angle.",
+        "event_text": "m_c trained extra hard to impress {PRONOUN/m_c/poss} mentor, r_c, but twisted {PRONOUN/m_c/poss} paw at an awkward angle.",
         "m_c": {
             "age": [
                 "adolescent"
@@ -4446,11 +4780,22 @@
             "status": [
                 "apprentice"
             ],
+            "relationship_status": [
+                "app/mentor"
+            ],
             "trait": [
                 "ambitious",
                 "daring",
                 "bold",
                 "loyal"
+            ]
+        },
+        "r_c": {
+            "age": [
+                "any"
+            ],
+            "status": [
+                "any"
             ]
         },
         "injury": [
@@ -4465,11 +4810,16 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_sprain_anyapprenticemultitrait3",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c was rushing around the camp in excitement for a patrol when {PRONOUN/m_c/poss} paw landed wrong on a rock! {PRONOUN/m_c/subject/CAP} took a tumble, and can't help limping the rest of the day.",
         "m_c": {
@@ -4499,11 +4849,16 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_sprain_anyapprenticemultitrait2",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c snuck out at night on a dare, but soon came hobbling back to camp, head lowered in embarrassment. Seems like {PRONOUN/m_c/poss} paw got caught on something in the dark and caused {PRONOUN/m_c/object} to trip!",
         "m_c": {
@@ -4539,11 +4894,16 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_sprain_anyapprenticemultitrait1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c overdid {PRONOUN/m_c/poss} last battle training session and sprained a paw.",
         "m_c": {
@@ -4574,13 +4934,18 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_crackedpads_anyapprenticemultitraitappmentor1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
-        "event_text": "m_c trained extra hard to impress {PRONOUN/m_c/poss} mentor, but now finds {PRONOUN/m_c/poss} paws to be sore and bleeding.",
+        "event_text": "m_c trained extra hard to impress {PRONOUN/m_c/poss} mentor, r_c, but now finds {PRONOUN/m_c/poss} paws to be sore and bleeding.",
         "m_c": {
             "age": [
                 "adolescent"
@@ -4588,11 +4953,22 @@
             "status": [
                 "apprentice"
             ],
+            "relationship_status": [
+                "app/mentor"
+            ],
             "trait": [
                 "ambitious",
                 "daring",
                 "bold",
                 "loyal"
+            ]
+        },
+        "r_c": {
+            "age": [
+                "any"
+            ],
+            "status": [
+                "any"
             ]
         },
         "injury": [
@@ -4607,13 +4983,18 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_sore_anyapprenticemultitraitappmentor1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
-        "event_text": "m_c trained extra hard to impress {PRONOUN/m_c/poss} mentor, but is extremely sore when {PRONOUN/m_c/subject} {VERB/m_c/wake/wakes} up the next morning.",
+        "event_text": "m_c trained extra hard to impress {PRONOUN/m_c/poss} mentor, r_c, but is extremely sore when {PRONOUN/m_c/subject} {VERB/m_c/wake/wakes} up the next morning.",
         "m_c": {
             "age": [
                 "adolescent"
@@ -4621,11 +5002,22 @@
             "status": [
                 "apprentice"
             ],
+            "relationship_status": [
+                "app/mentor"
+            ],
             "trait": [
                 "ambitious",
                 "daring",
                 "bold",
                 "loyal"
+            ]
+        },
+        "r_c": {
+            "age": [
+                "any"
+            ],
+            "status": [
+                "any"
             ]
         },
         "injury": [
@@ -4640,240 +5032,16 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_clawwoundcatbite_anyapprenticemultitraitappmentorothercat1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c fought a big dog and was badly injured.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "trait": [
-                "adventurous",
-                "ambitious",
-                "bloodthirsty",
-                "bold",
-                "daring",
-                "fierce",
-                "vengeful"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "broken bone"
-                ],
-                "scars": [
-                    "MANLEG"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by a big dog.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after fighting a big dog."
-        }
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c saved r_c from a big dog, but was badly injured.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": [],
-            "trait": [
-                "altruistic",
-                "compassionate",
-                "loving",
-                "empathetic",
-                "responsible",
-                "loyal",
-                "adventurous",
-                "ambitious",
-                "bloodthirsty",
-                "bold",
-                "daring",
-                "fierce",
-                "vengeful"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "broken bone"
-                ],
-                "scars": [
-                    "MANTAIL"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by a big dog while rescuing r_c.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after saving r_c from a big dog."
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect",
-                    "dislike"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c fought a hawk and got hurt.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "trait": [
-                "adventurous",
-                "ambitious",
-                "bloodthirsty",
-                "bold",
-                "daring",
-                "fierce",
-                "vengeful"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "claw-wound"
-                ],
-                "scars": [
-                    "ONE"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by a hawk.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after fighting a hawk."
-        }
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c saved r_c from a hawk, but was hurt.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": [],
-            "trait": [
-                "altruistic",
-                "compassionate",
-                "loving",
-                "empathetic",
-                "responsible",
-                "loyal",
-                "adventurous",
-                "ambitious",
-                "bloodthirsty",
-                "bold",
-                "daring",
-                "fierce",
-                "vengeful"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "claw-wound"
-                ],
-                "scars": [
-                    "TWO"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by a hawk while rescuing r_c.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after saving r_c from a hawk."
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c was hurt by r_c for not defending the territory well enough.",
         "m_c": {
@@ -4894,8 +5062,17 @@
             ]
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ],
             "trait": [
                 "bloodthirsty",
                 "cold",
@@ -4912,10 +5089,12 @@
                     "m_c"
                 ],
                 "injuries": [
-                    "claw-wound"
+                    "claw-wound",
+                    "cat bite"
                 ],
                 "scars": [
-                    "BRIDGE"
+                    "BRIDGE",
+                    "CATBITE"
                 ]
             }
         ],
@@ -4932,22 +5111,38 @@
                     "r_c"
                 ],
                 "values": [
-                    "dislike",
                     "platonic",
                     "comfort",
                     "trust",
                     "respect"
                 ],
-                "amount": -5
+                "amount": -10
+            },
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": 10
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_clawwoundcatbite_anyapprenticemultitraitappmentorothercat3",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c was hurt by {PRONOUN/m_c/poss} mentor, r_c, as a punishment for accidentally wandering over the border.",
         "m_c": {
@@ -4962,8 +5157,17 @@
             ]
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ],
             "trait": [
                 "bloodthirsty",
                 "cold",
@@ -4980,10 +5184,12 @@
                     "m_c"
                 ],
                 "injuries": [
-                    "claw-wound"
+                    "claw-wound",
+                    "cat bite"
                 ],
                 "scars": [
-                    "TOETRAP"
+                    "TOETRAP",
+                    "CATBITE"
                 ]
             }
         ],
@@ -5000,22 +5206,38 @@
                     "r_c"
                 ],
                 "values": [
-                    "dislike",
                     "platonic",
                     "comfort",
                     "trust",
                     "respect"
                 ],
-                "amount": -5
+                "amount": -10
+            },
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": 10
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_clawwoundcatbite_anyapprenticemultitraitappmentorothercat2",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c was hurt by {PRONOUN/m_c/poss} mentor, r_c, as a punishment for messing with a Twoleg object.",
         "m_c": {
@@ -5036,8 +5258,17 @@
             ]
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ],
             "trait": [
                 "bloodthirsty",
                 "cold",
@@ -5054,10 +5285,12 @@
                     "m_c"
                 ],
                 "injuries": [
-                    "claw-wound"
+                    "claw-wound",
+                    "cat bite"
                 ],
                 "scars": [
-                    "TAILSCAR"
+                    "TAILSCAR",
+                    "CATBITE"
                 ]
             }
         ],
@@ -5074,22 +5307,38 @@
                     "r_c"
                 ],
                 "values": [
-                    "dislike",
                     "platonic",
                     "comfort",
                     "trust",
                     "respect"
                 ],
-                "amount": -5
+                "amount": -10
+            },
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": 10
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_clawwound_anyapprenticemultitraitappmentorothercatskillfighter",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c and r_c were practicing battle moves. r_c insisted they keep their claws out, and m_c got hurt.",
         "m_c": {
@@ -5104,8 +5353,17 @@
             ]
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ],
             "skill": [
                 "FIGHTER,1"
             ],
@@ -5146,22 +5404,38 @@
                     "r_c"
                 ],
                 "values": [
-                    "dislike",
                     "platonic",
                     "comfort",
                     "trust",
                     "respect"
                 ],
-                "amount": -5
+                "amount": -10
+            },
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": 10
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_clawwoundcatbite_anyapprenticemultitraitappmentorothercat1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c was hurt by {PRONOUN/m_c/poss} mentor, r_c, as a punishment for disobeying {PRONOUN/r_c/object}.",
         "m_c": {
@@ -5181,8 +5455,17 @@
             ]
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ],
             "trait": [
                 "bloodthirsty",
                 "cold",
@@ -5198,10 +5481,12 @@
                     "m_c"
                 ],
                 "injuries": [
-                    "claw-wound"
+                    "claw-wound",
+                    "cat bite"
                 ],
                 "scars": [
-                    "LEFTEAR"
+                    "LEFTEAR",
+                    "CATBITE"
                 ]
             }
         ],
@@ -5218,22 +5503,38 @@
                     "r_c"
                 ],
                 "values": [
-                    "dislike",
                     "platonic",
                     "comfort",
                     "trust",
                     "respect"
                 ],
-                "amount": -5
+                "amount": -10
+            },
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": 10
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_clawwoundcatbite_anyapprenticemultitraitappmentorothercat1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c fought with {PRONOUN/m_c/poss} mentor, r_c, and was injured.",
         "m_c": {
@@ -5248,8 +5549,17 @@
             ]
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ],
             "skill": [
                 "FIGHTER,1"
             ],
@@ -5268,10 +5578,12 @@
                     "m_c"
                 ],
                 "injuries": [
-                    "claw-wound"
+                    "claw-wound",
+                    "cat bite"
                 ],
                 "scars": [
-                    "CHEEK"
+                    "CHEEK",
+                    "CATBITE"
                 ]
             }
         ],
@@ -5288,24 +5600,40 @@
                     "r_c"
                 ],
                 "values": [
-                    "dislike",
                     "platonic",
                     "comfort",
                     "trust",
                     "respect"
                 ],
-                "amount": -5
+                "amount": -10
+            },
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": 10
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_clawwound_anyapprenticemultitraitappmentorothercat1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
-        "event_text": "m_c could not handle {PRONOUN/m_c/poss} mentor's harsh training, and was injured as a result.",
+        "event_text": "m_c could not handle {PRONOUN/m_c/poss} mentor's, r_c, harsh training, and was injured as a result.",
         "m_c": {
             "age": [
                 "adolescent"
@@ -5330,8 +5658,17 @@
             ]
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ],
             "trait": [
                 "bloodthirsty",
                 "cold",
@@ -5367,24 +5704,40 @@
                     "r_c"
                 ],
                 "values": [
-                    "dislike",
                     "platonic",
                     "comfort",
                     "trust",
                     "respect"
                 ],
-                "amount": -5
+                "amount": -10
+            },
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": 10
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_mangledleg_anyapprenticeappmentorothercat1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
-        "event_text": "m_c's leg was badly hurt after {PRONOUN/m_c/poss} mentor used a Twoleg trap during a training exercise.",
+        "event_text": "m_c's leg was badly hurt after r_c, {PRONOUN/m_c/poss} mentor, used a Twoleg trap during a training exercise.",
         "m_c": {
             "age": [
                 "adolescent"
@@ -5397,8 +5750,17 @@
             ]
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ],
             "trait": [
                 "bloodthirsty",
                 "cold",
@@ -5433,56 +5795,52 @@
                     "r_c"
                 ],
                 "values": [
-                    "dislike",
                     "platonic",
                     "comfort",
                     "trust",
                     "respect"
                 ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was climbing a tree when {PRONOUN/m_c/subject} fell. Luckily, {PRONOUN/m_c/subject} {VERB/m_c/were/was} only bruised by the incident.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
+                "amount": -10
+            },
             {
-                "cats": [
+                "cats_from": [
                     "m_c"
                 ],
-                "injuries": [
-                    "bruises"
-                ]
+                "cats_to": [
+                    "r_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": 10
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_crackedpads_anymultiage1",
+        "biome": [
+            "any"
+        ],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c stepped on some sharp stones while walking along the shoreline.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -5496,45 +5854,30 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_waterintheirlungs_anymultiage1",
+        "biome": [
+            "any"
+        ],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was climbing a tree and got a splinter from one of the branches.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "small cut"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c was dragged out into the ocean by the tide, and inhaled a lot of water before managing to get out. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'ve/'s} been hacking and sputtering ever since.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -5551,16 +5894,30 @@
         }
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_snakebite_anymultiage1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c was bitten by a snake, and miraculously survived!",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -5581,16 +5938,30 @@
         }
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_bruises_anymultisage2",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c wasn't looking where {PRONOUN/m_c/subject} {VERB/m_c/were/was} going and tripped over a small trunk, gaining a few bruises.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -5604,16 +5975,30 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_dislocatedjoint_anymultiage2",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c misstepped and slipped from a rock, dislocating a joint.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -5627,16 +6012,30 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_dislocatedjoint_anymultiage1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c slipped on some rocks and dislocated {PRONOUN/m_c/poss} leg.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -5650,16 +6049,30 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_sprain_anymultiage5",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c slipped on some rocks and twisted {PRONOUN/m_c/poss} paw.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -5673,16 +6086,30 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_sprain_anymultiage4",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c leapt from a rock, but {PRONOUN/m_c/subject} didn't land quite right.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -5696,16 +6123,30 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_sprain_anymultiage3",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c misstepped and slipped from a rock, spraining {PRONOUN/m_c/poss} paw.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -5719,16 +6160,30 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_sprain_anymultiage2",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c wasn't looking where {PRONOUN/m_c/subject} {VERB/m_c/were/was} going and tripped over a small trunk, spraining {PRONOUN/m_c/poss} paw.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -5742,16 +6197,30 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_sprain_anymultiage1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c got {PRONOUN/m_c/poss} paw stuck in a Twoleg trap, but luckily escaped with only a sprain.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -5765,16 +6234,30 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_crackedpads_any2",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c ran too fast over harsh ground and hurt {PRONOUN/m_c/poss} paws.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -5788,16 +6271,24 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_crackedpads_any1",
         "season": [
             "leaf-bare"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "The weather has been cold and dry, and m_c's paw pads have cracked as a result.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -5811,16 +6302,30 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_crackedpads_anyskillcampmultitrait1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c helped to strengthen the camp walls, but scraped up {PRONOUN/m_c/poss} paw pads in the process.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ],
             "skill": [
                 "CAMP,2"
             ],
@@ -5845,16 +6350,30 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_sore_anymultiage2",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c overexerted {PRONOUN/m_c/self}, and is feeling extremely sore.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -5868,277 +6387,128 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
-        "season": [
+        "event_id": "gen_injury_tornpelt_anyskillclevermultitrait2",
+        "biome": [
             "any"
         ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was out on a walk alone when {PRONOUN/m_c/subject} heard a dog approaching! {PRONOUN/m_c/subject/CAP} crawled into a thorny shrub to hide, but got some nasty scratches in the process.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "skill": [
-                "CLEVER,1"
-            ],
-            "trait": [
-                "nervous",
-                "wise",
-                "insecure",
-                "careful",
-                "calm",
-                "sneaky",
-                "strange"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "torn pelt"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was out on a walk alone when {PRONOUN/m_c/subject} heard a fox approaching! {PRONOUN/m_c/subject/CAP} crawled into a thorny shrub to hide, but got some nasty scratches in the process.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "skill": [
-                "CLEVER,1"
-            ],
-            "trait": [
-                "nervous",
-                "wise",
-                "insecure",
-                "careful",
-                "calm",
-                "sneaky",
-                "strange"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "torn pelt"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was hurt by r_c for disobeying orders.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
-            "not_trait": [
-                "loyal",
-                "ambitious"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": [],
-            "trait": [
-                "bloodthirsty",
-                "bold",
-                "cold",
-                "fierce",
-                "righteous",
-                "strict",
-                "vengeful"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "claw-wound"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by r_c for disobeying orders.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after being hurt by r_c for disobeying {PRONOUN/r_c/object}."
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "dislike",
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was hurt by r_c for speaking out against {PRONOUN/r_c/object}.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
-            "not_trait": [
-                "loyal"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": [],
-            "trait": [
-                "bloodthirsty",
-                "bold",
-                "cold",
-                "fierce",
-                "righteous",
-                "strict",
-                "vengeful",
-                "ambitious"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "claw-wound"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by r_c for speaking out against {PRONOUN/r_c/object}.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after being hurt by r_c for {PRONOUN/m_c/poss} dissent."
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "dislike",
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was hurt by r_c to make an example out of {PRONOUN/m_c/object}.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [],
-            "status": [],
-            "trait": [
-                "bloodthirsty",
-                "bold",
-                "cold",
-                "fierce",
-                "righteous",
-                "strict",
-                "vengeful"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "claw-wound"
-                ],
-                "scars": [
-                    "ONE"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by r_c to make an example out of {PRONOUN/m_c/object}.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after being hurt by r_c to make an example out of {PRONOUN/m_c/object}."
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "dislike",
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [],
+        "weight": 20,
+        "event_text": "m_c was out on a walk alone when {PRONOUN/m_c/subject} heard a dog approaching! {PRONOUN/m_c/subject/CAP} crawled into a thorny shrub to hide, but got some nasty scratches in the process.",
+        "m_c": {
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ],
+            "skill": [
+                "CLEVER,1"
+            ],
+            "trait": [
+                "nervous",
+                "wise",
+                "insecure",
+                "careful",
+                "calm",
+                "sneaky",
+                "strange"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "torn pelt"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_tornpelt_anyskillclevermultitrait1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
+        "weight": 20,
+        "event_text": "m_c was out on a walk alone when {PRONOUN/m_c/subject} heard a fox approaching! {PRONOUN/m_c/subject/CAP} crawled into a thorny shrub to hide, but got some nasty scratches in the process.",
+        "m_c": {
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ],
+            "skill": [
+                "CLEVER,1"
+            ],
+            "trait": [
+                "nervous",
+                "wise",
+                "insecure",
+                "careful",
+                "calm",
+                "sneaky",
+                "strange"
+            ]
+        },
+        "injury": [
+            {
+                "cats": [
+                    "m_c"
+                ],
+                "injuries": [
+                    "torn pelt"
+                ]
+            }
+        ]
+    },
+    {
+        "event_id": "gen_injury_clawwound_any1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
+        "season": [
+            "any"
+        ],
         "weight": 20,
         "event_text": "m_c fought a rogue, and while {PRONOUN/m_c/subject} drove the trespasser away, {PRONOUN/m_c/subject} needed to be rushed to the medicine den afterwards.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -6160,16 +6530,30 @@
         }
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_mangledtail_any1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c got {PRONOUN/m_c/poss} paw stuck in a Twoleg trap, and while {PRONOUN/m_c/subject} eventually escaped, {PRONOUN/m_c/poss} leg is heavily injured.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -6190,25 +6574,42 @@
         }
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_mangledtail_anyothercatleader1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c was maimed by r_c for questioning {PRONOUN/r_c/poss} leadership.",
         "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ],
             "not_trait": [
                 "loyal",
                 "ambitious"
             ]
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [
+                "any"
+            ],
+            "status": [
+                "leader"
+            ],
             "trait": [
                 "ambitious",
                 "bloodthirsty",
@@ -6247,27 +6648,52 @@
                     "r_c"
                 ],
                 "values": [
-                    "dislike",
                     "platonic",
                     "comfort",
                     "trust",
                     "respect"
                 ],
-                "amount": -5
+                "amount": -15
+            },
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": 15
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_mangledtail_anynotskillfighter2",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c's tail was badly injured by a dog.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult",
+                "elder"
+            ],
+            "status": [
+                "any"
+            ],
             "not_skill": [
                 "FIGHTER,2"
             ]
@@ -6291,16 +6717,25 @@
         }
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_mangledtail_anynotskillfighter1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c's tail was badly injured by a fox.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [
+                "any"
+            ],
+            "status": [
+                "any"
+            ],
             "not_skill": [
                 "FIGHTER,2"
             ]
@@ -6324,25 +6759,38 @@
         }
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_catbite_anyothercat1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c was hurt by r_c for disobeying orders.",
         "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
+            "age": [
+                "any"
+            ],
+            "status": [
+                "any"
+            ],
             "not_trait": [
                 "loyal",
                 "ambitious"
             ]
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [
+                "any"
+            ],
+            "status": [
+                "leader",
+                "deputy"
+            ],
             "trait": [
                 "bloodthirsty",
                 "bold",
@@ -6359,7 +6807,8 @@
                     "m_c"
                 ],
                 "injuries": [
-                    "cat bite"
+                    "cat bite",
+                    "claw-wound"
                 ]
             }
         ],
@@ -6375,36 +6824,63 @@
                 "cats_to": [
                     "r_c"
                 ],
+                "mutual": true,
                 "values": [
-                    "dislike",
                     "platonic",
                     "comfort",
                     "trust",
                     "respect"
                 ],
-                "amount": -5
+                "amount": -15
+            },
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "mutual": true,
+                "values": [
+                    "dislike"
+                ],
+                "amount": 15
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_catbite_anyothercat2",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c was hurt by r_c for speaking out against {PRONOUN/r_c/object}.",
         "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
+            "age": [
+                "any"
+            ],
+            "status": [
+                "any"
+            ],
             "not_trait": [
                 "loyal"
             ]
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [
+                "any"
+            ],
+            "status": [
+                "leader",
+                "deputy",
+                "medicine cat"
+            ],
             "trait": [
                 "bloodthirsty",
                 "bold",
@@ -6421,7 +6897,8 @@
                     "m_c"
                 ],
                 "injuries": [
-                    "cat bite"
+                    "cat bite",
+                    "claw-wound"
                 ]
             }
         ],
@@ -6437,33 +6914,59 @@
                 "cats_to": [
                     "r_c"
                 ],
+                "mutual": true,
                 "values": [
-                    "dislike",
                     "platonic",
                     "comfort",
                     "trust",
                     "respect"
                 ],
-                "amount": -5
+                "amount": -15
+            },
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "mutual": true,
+                "values": [
+                    "dislike"
+                ],
+                "amount": 15
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_catbite_anyothercatleader1",
+        "biome": [
+            "any"
+        ],
+        "camp": [
+            "any"
+        ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c was hurt by r_c to make an example out of {PRONOUN/m_c/object}.",
         "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": []
+            "age": [
+                "any"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [
+                "any"
+            ],
+            "status": [
+                "leader",
+                "deputy"
+            ],
             "trait": [
                 "bloodthirsty",
                 "bold",
@@ -6480,10 +6983,12 @@
                     "m_c"
                 ],
                 "injuries": [
-                    "cat bite"
+                    "cat bite",
+                    "claw-wound"
                 ],
                 "scars": [
-                    "CATBITE"
+                    "CATBITE",
+                    "ONE"
                 ]
             }
         ],
@@ -6499,31 +7004,54 @@
                 "cats_to": [
                     "r_c"
                 ],
+                "mutual": true,
                 "values": [
-                    "dislike",
                     "platonic",
                     "comfort",
                     "trust",
                     "respect"
                 ],
-                "amount": -5
+                "amount": -15
+            },
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "mutual": true,
+                "values": [
+                    "dislike"
+                ],
+                "amount": 15
             }
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_smallcut_anymultiage1",
+        "biome": [
+            "any"
+        ],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c was helping reinforce the camp walls when {PRONOUN/m_c/subject} got a thorn stuck in {PRONOUN/m_c/poss} paw.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "senior",
+                "adolescent",
+                "young adult",
+                "adult",
+                "senior adult"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -6537,19 +7065,25 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_smallcut_any1",
+        "biome": [
+            "any"
+        ],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c was trying to fluff up {PRONOUN/m_c/poss} nest when {PRONOUN/m_c/subject} discovered that {PRONOUN/m_c/subject} {VERB/m_c/were/was} the victim of a prank. Fox-dung! There's now a sharp thorn embedded in {PRONOUN/m_c/poss} paw.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "any"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -6563,7 +7097,7 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_beesting_multiany3",
         "camp": [
             "any"
         ],
@@ -6571,12 +7105,15 @@
             "greenleaf",
             "newleaf"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c found a patch of flowering catmint! No one else is around, so {PRONOUN/m_c/subject} bend down and take a big bite-- Yowch! A bee! {PRONOUN/m_c/subject/CAP} come home with a swollen face...",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "any"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -6597,19 +7134,30 @@
         }
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_tornear_anymultistatus2",
+        "biome": [
+            "any"
+        ],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c accidentally crossed the border on patrol and got {PRONOUN/m_c/poss} ear torn by an enemy warrior.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "any"
+            ],
+            "status": [
+                "apprentice",
+                "deputy",
+                "leader",
+                "warrior",
+                "medicine cat",
+                "medicine cat apprentice"
+            ]
         },
         "injury": [
             {
@@ -6626,22 +7174,39 @@
         ],
         "history": {
             "scar": "m_c's ear was torn when {PRONOUN/m_c/subject} accidentally crossed the border and was caught by an enemy warrior."
+        },
+        "other_clan": {
+            "current_rep": [
+                "any"
+            ],
+            "changed": -5
         }
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_tornear_anymultistatus1",
+        "biome": [
+            "any"
+        ],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c caught a cat from another Clan trespassing on their territory and {PRONOUN/m_c/poss} ear was torn in the ensuing scuffle.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "any"
+            ],
+            "status": [
+                "apprentice",
+                "warrior",
+                "leader",
+                "deputy",
+                "medicine cat",
+                "medicine cat apprentice"
+            ]
         },
         "injury": [
             {
@@ -6658,22 +7223,34 @@
         ],
         "history": {
             "scar": "m_c's ear was torn in a scuffle when {PRONOUN/m_c/subject} chased off an enemy warrior."
+        },
+        "other_clan": {
+            "current_rep": [
+                "any"
+            ],
+            "changed": -5
         }
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_ratbite_anyany1",
+        "biome": [
+            "any"
+        ],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c was attacked by a group of rats! {PRONOUN/m_c/subject/CAP} managed to fight them off, but didn't escape unscathed.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "any"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -6695,7 +7272,10 @@
         }
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_beesting_multiany2",
+        "biome": [
+            "any"
+        ],
         "camp": [
             "any"
         ],
@@ -6703,12 +7283,15 @@
             "greenleaf",
             "newleaf"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "The day is so nice out today that m_c decided to sneak out of camp and go play in the flowers without anyone noticing. {PRONOUN/m_c/subject/CAP} come back with a swollen paw, having stepped on a bee.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "any"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -6724,12 +7307,15 @@
             }
         ],
         "history": {
-            "scar": "m_c, unbelievably, was scarred when {PRONOUN/m_c/subject} tried to eat a bee.",
+            "scar": "m_c, unbelievably, was scarred when {PRONOUN/m_c/subject} stepped on a bee.",
             "reg_death": "m_c died from complications caused by a bee sting."
         }
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_beesting_multiany1",
+        "biome": [
+            "any"
+        ],
         "camp": [
             "any"
         ],
@@ -6737,12 +7323,15 @@
             "greenleaf",
             "newleaf"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "Camp was supposed to be safe, but m_c found bees trying to form a hive in a corner of camp. Annoyed by {PRONOUN/m_c/poss} buzzing, m_c attacks them, and got swarmed by bees.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "any"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -6753,7 +7342,7 @@
                     "bee sting"
                 ],
                 "scars": [
-                    "BOTHBLIND"
+                    "BRIDGE"
                 ]
             }
         ],
@@ -6763,19 +7352,25 @@
         }
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_headache_anyany1",
+        "biome": [
+            "any"
+        ],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c woke up with a mild headache, but went about {PRONOUN/m_c/poss} day anyway, trying to ignore the nagging pain.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "any"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -6789,19 +7384,25 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_severeheadache_anyany1",
+        "biome": [
+            "any"
+        ],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "m_c woke up with a splitting headache, and couldn't get out of {PRONOUN/m_c/poss} nest. {PRONOUN/m_c/subject/CAP} spent the entire day curled up, trying to avoid light and noise so that the throbbing pain could subside.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "any"
+            ],
+            "status": [
+                "any"
+            ]
         },
         "injury": [
             {
@@ -6815,20 +7416,33 @@
         ]
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_mangledleg_anymultistatusnotcareful1",
+        "biome": [
+            "any"
+        ],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [],
         "weight": 20,
         "event_text": "While patrolling the o_c borders, m_c stepped on a concealed pit trap set by what seemed to be o_c warriors. m_c freezes with shock as {PRONOUN/m_c/subject} {VERB/m_c/plunge/plunges} into the depths of the trap, causing m_c to limp back to camp, flanked by other cats on the patrol.",
         "m_c": {
-            "age": [],
-            "status": [],
-            "not_trait": "careful"
+            "age": [
+                "any"
+            ],
+            "status": [
+                "apprentice",
+                "warrior",
+                "medicine cat",
+                "medicine cat apprentice",
+                "leader",
+                "deputy"
+            ],
+            "not_trait": [
+                "careful"
+            ]
         },
         "injury": [
             {
@@ -6844,24 +7458,37 @@
             "current_rep": [
                 "hostile"
             ],
-            "changed": -5
+            "changed": -10
         }
     },
     {
-        "event_id": "gen_injury_",
+        "event_id": "gen_injury_war_clawwound_anymultitraitmultistatus1",
+        "biome": [
+            "any"
+        ],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [],
+        "sub_type": [
+            "war"
+        ],
         "weight": 20,
         "event_text": "During a skirmish, m_c bounds into battle against an o_c warrior, protecting r_c from a powerful blow. m_c bears the brunt of the strike, and r_c helps them back to camp.",
         "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
+            "age": [
+                "adult",
+                "senior adult",
+                "senior",
+                "young adult"
+            ],
+            "status": [
+                "warrior",
+                "leader",
+                "deputy"
+            ],
             "trait": [
                 "fierce",
                 "bloodthirsty",
@@ -6878,8 +7505,17 @@
             ]
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [
+                "adult",
+                "senior adult",
+                "senior",
+                "young adult"
+            ],
+            "status": [
+                "warrior",
+                "leader",
+                "deputy"
+            ]
         },
         "injury": [
             {
@@ -6899,11 +7535,12 @@
                 "cats_to": [
                     "m_c"
                 ],
+                "mutual": true,
                 "values": [
                     "trust",
                     "respect"
                 ],
-                "amount": 5
+                "amount": 15
             }
         ],
         "other_clan": {
@@ -6912,894 +7549,5 @@
             ],
             "changed": -5
         }
-    },
-    {
-        "event_id": "gen_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "While o_c attempted a surprise attack on the c_n camp, m_c fiercely guarded the nursery. However, it didn't end with m_c unscathed, and {PRONOUN/m_c/subject} walked away with a gushing wound in {PRONOUN/m_c/poss} flank.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "claw-wound"
-                ]
-            }
-        ],
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": -5
-        }
-    },
-    {
-        "event_id": "gen_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "On a border patrol near the o_c border, m_c could no longer take o_c's jeers and smirks. {PRONOUN/m_c/subject/CAP} lashed out at the first jeering cat {PRONOUN/m_c/subject} saw, although the hotheaded move wasn't smart as m_c couldn't escape the skirmish without injury.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "trait": [
-                "troublesome",
-                "fierce",
-                "bloodthirsty",
-                "cold",
-                "bold",
-                "daring",
-                "righteous",
-                "ambitious",
-                "confident",
-                "adventurous",
-                "shameless",
-                "vengeful",
-                "arrogant",
-                "competitive",
-                "flamboyant",
-                "rebellious"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "cat bite"
-                ]
-            }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": -5
-        }
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c tried to sneak out of the camp, but fell and got a bruise before {PRONOUN/m_c/subject} even left the safety of the camp walls.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "trait": [
-                "daring",
-                "impulsive",
-                "inquisitive",
-                "troublesome"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "bruises"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c snuck out of camp and returned a bit bruised, but brimming with pride despite the scolding {PRONOUN/m_c/subject} {VERB/m_c/were/was} given.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "trait": [
-                "daring",
-                "impulsive",
-                "inquisitive",
-                "troublesome"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "bruises"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c play-fought a bit too hard and got a little bruised.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "trait": [
-                "daring",
-                "bouncy",
-                "bullying",
-                "impulsive",
-                "noisy",
-                "troublesome"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "bruises"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c tried to sneak out of the camp, but fell and scraped {PRONOUN/m_c/poss} paw before {PRONOUN/m_c/subject} even left the safety of the camp walls.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "trait": [
-                "daring",
-                "impulsive",
-                "inquisitive",
-                "troublesome"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "scrapes"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c snuck out of camp and returned scraped up, but brimming with pride despite the scolding {PRONOUN/m_c/subject} {VERB/m_c/were/was} given.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "trait": [
-                "daring",
-                "impulsive",
-                "inquisitive",
-                "troublesome"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "scrapes"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c play-fought a bit too hard and scraped {PRONOUN/m_c/self} up.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "trait": [
-                "daring",
-                "bouncy",
-                "bullying",
-                "impulsive",
-                "noisy",
-                "troublesome"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "scrapes"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c woke up with a mild headache, but got up to play anyways, trying to ignore the nagging pain.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "headache"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c woke up with a splitting headache, and couldn't get out of {PRONOUN/m_c/poss} nest. {PRONOUN/m_c/subject/CAP} spent the entire day curled up in the nursery, trying to avoid light and noise so that the throbbing pain could subside.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "severe headache"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was climbing a tree when {PRONOUN/m_c/subject} fell. Luckily, {PRONOUN/m_c/subject} {VERB/m_c/were/was} only bruised by the incident.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "bruises"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c trips over an unseen rabbit hole, spraining {PRONOUN/m_c/poss} paw.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "sprain"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was pushing through some dense shrubs and felt the branches tear painfully at {PRONOUN/m_c/poss} pelt.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "torn pelt"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was climbing a tree and got a splinter from one of the branches.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "small cut"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was moving some branches out of the way when {PRONOUN/m_c/subject} got a splinter.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "small cut"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "leaf-fall",
-            "leaf-bare"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was out wandering the territory for a bit too long and came back with frostbite.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "frostbite"
-                ],
-                "scars": [
-                    "FROSTTAIL"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by frostbite.",
-            "reg_death": "m_c died after {PRONOUN/m_c/subject} got frostbite."
-        }
-    },
-    {
-        "event_id": "gen_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf",
-            "newleaf",
-            "leaf-fall"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c fell into a river, and inhaled a lot of water before managing to get out. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'ve/'s} been hacking and sputtering ever since.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "water in their lungs"
-                ]
-            }
-        ],
-        "history": {
-            "reg_death": "m_c died from water-inhalation after falling in the river."
-        }
-    },
-    {
-        "event_id": "gen_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c's tail was badly injured by a falling tree.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "mangled tail"
-                ],
-                "scars": [
-                    "MANTAIL"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by a falling tree.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after a tree fell on {PRONOUN/m_c/object}."
-        }
-    },
-    {
-        "event_id": "gen_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "A fire rages through the forest. m_c manages to escape, though not unscathed by the experience.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "burn"
-                ],
-                "scars": [
-                    "BURNRUMP"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c's pelt was burned by a forest fire.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} burns after a forest fire."
-        }
-    },
-    {
-        "event_id": "gen_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "The dry greenleaf weather leads to a fire bursting to life in camp, dangerously close to the nursery. There's still one kit inside! m_c dives into the den and makes it out, burnt, but with r_c safely swinging in {PRONOUN/m_c/poss} grasp.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
-            "trait": [
-                "ambitious",
-                "bold",
-                "altruistic",
-                "daring",
-                "fierce",
-                "responsible"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "burn"
-                ],
-                "scars": [
-                    "BURNPAWS"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c's pelt was burned by a forest fire.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} burns after a forest fire."
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect",
-                    "dislike"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "A fire rages through the forest and m_c manages to escape, though not unscathed by the experience.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "severe burn"
-                ],
-                "scars": [
-                    "BURNTAIL"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c's pelt was burned by a forest fire.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} burns after a forest fire."
-        }
-    },
-    {
-        "event_id": "gen_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "The dry greenleaf weather leads to a fire bursting to life in camp, dangerously close to the nursery. There's still one kit inside! m_c dives into the den and makes it out, burnt, but with r_c safely swinging in {PRONOUN/m_c/poss} grasp.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
-            "trait": [
-                "ambitious",
-                "bold",
-                "altruistic",
-                "daring",
-                "fierce",
-                "responsible"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "severe burn"
-                ],
-                "scars": [
-                    "BURNBELLY"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c's pelt was burned by a forest fire.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} burns after a forest fire."
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect",
-                    "dislike"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "newleaf",
-            "leaf-bare"
-        ],
-        "tags": [
-            "FROSTPAWS"
-        ],
-        "weight": 20,
-        "event_text": "m_c and r_c talked each other into walking onto the ice of the frozen pond that lay not far from camp. It was a dare at first, but when m_c didn't immediately fall in, r_c joined {PRONOUN/m_c/object}. The two cats playfully slipped around for a bit before the minute cracks reached their ears. r_c fell in first, and, without thinking, m_c leaped in after {PRONOUN/r_c/object}. m_c was able to drag r_c out of the water and the two leaned on each other on the way back to camp.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
-            "skill": [
-                "SWIMMER,3"
-            ],
-            "trait": [
-                "daring",
-                "adventurous",
-                "oblivious",
-                "bold",
-                "childish"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": [],
-            "trait": [
-                "daring",
-                "adventurous",
-                "oblivious",
-                "bold",
-                "childish"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "shivering"
-                ],
-                "scars": []
-            }
-        ],
-        "history": {
-            "scar": "m_c got frostbitten after falling into a frozen pond.",
-            "reg_death": "m_c died from the cold after falling into a frozen pond."
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect",
-                    "dislike"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "Chasing a mouse through a dense area, m_c accidentally collides with a low-hanging branch, leaving them to return to camp empty-pawed and with splitting head pain.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "trait": [
-                "ambitious",
-                "childish",
-                "playful",
-                "bold",
-                "daring",
-                "confident",
-                "adventurous",
-                "competitive",
-                "oblivious"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "headache"
-                ]
-            }
-        ]
-    }]
+    }
+]

--- a/resources/dicts/events/injury/mountainous.json
+++ b/resources/dicts/events/injury/mountainous.json
@@ -1,98 +1,20 @@
 [
     {
-        "event_id": "mtn_injury_",
-        "biome": [
-            "mountainous"
-        ],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c went out for a walk, but slipped on the ice and broke a bone.",
-        "m_c": {
-            "age": [
-                "senior",
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "elder"
-            ],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "broken bone"
-                ],
-                "scars": [
-                    "TOETRAP"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred after slipping on ice.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after slipping on ice."
-        }
-    },
-    {
-        "event_id": "mtn_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was grabbed and dropped by an eagle, but {PRONOUN/m_c/subject} somehow survived.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "broken bone"
-                ],
-                "scars": [
-                    "TWO"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred when an eagle grabbed {PRONOUN/m_c/object}.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after an eagle grabbed {PRONOUN/m_c/object}."
-        }
-    },
-    {
-        "event_id": "mtn_injury_",
-        "season": [
-            "leaf-fall",
-            "leaf-bare"
-        ],
-        "tags": [],
+        "event_id": "mtn_injury_brokenbone_multiany1",
+        "biome": ["mountainous"],
+        "camp": ["any"],
+        "season": ["leaf-fall", "leaf-bare"],
         "weight": 20,
         "event_text": "m_c thought {PRONOUN/m_c/subject} {VERB/m_c/were/was} walking on a snowdrift till it gave way and {PRONOUN/m_c/subject} fell down the mountain, breaking {PRONOUN/m_c/poss} leg.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": ["any"],
+            "status": ["any"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "broken bone"
-                ],
-                "scars": [
-                    "SIDE"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["broken bone"],
+                "scars": ["SIDE"]
             }
         ],
         "history": {
@@ -101,29 +23,21 @@
         }
     },
     {
-        "event_id": "mtn_injury_",
-        "season": [
-            "leaf-fall",
-            "leaf-bare"
-        ],
-        "tags": [],
+        "event_id": "mtn_injury_brokenbone_anyany1",
+        "biome": ["mountainous"],
+        "camp": ["any"],
+        "season": ["any"],
         "weight": 20,
         "event_text": "m_c fell from a cliff and somehow survived, though not without breaking {PRONOUN/m_c/poss} leg.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": ["any"],
+            "status": ["any"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "broken bone"
-                ],
-                "scars": [
-                    "MANLEG"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["broken bone"],
+                "scars": ["MANLEG"]
             }
         ],
         "history": {
@@ -132,209 +46,21 @@
         }
     },
     {
-        "event_id": "mtn_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was climbing a tree when {PRONOUN/m_c/subject} fell. Luckily, {PRONOUN/m_c/subject} {VERB/m_c/were/was} only bruised by the incident.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "bruises"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "mtn_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was pushing through some dense shrubs and felt the branches tear painfully at {PRONOUN/m_c/poss} pelt.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "torn pelt"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "mtn_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c survived a vicious eagle attack - with the claw marks to prove it!",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "claw-wound"
-                ],
-                "scars": [
-                    "ONE"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by an eagle.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after fighting an eagle."
-        }
-    },
-    {
-        "event_id": "mtn_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was climbing a tree and got a splinter from one of the branches.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "small cut"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "mtn_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was moving some branches out of the way when {PRONOUN/m_c/subject} got a splinter.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "small cut"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "mtn_injury_",
-        "season": [
-            "leaf-fall",
-            "leaf-bare"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was out wandering the territory for a bit too long and came back with frostbite.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "frostbite"
-                ],
-                "scars": [
-                    "FROSTMITT"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by frostbite.",
-            "reg_death": "m_c died after {PRONOUN/m_c/subject} got frostbite."
-        }
-    },
-    {
-        "event_id": "mtn_injury_",
-        "season": [
-            "greenleaf",
-            "newleaf",
-            "leaf-fall"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c fell into a river, and inhaled a lot of water before managing to get out. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'ve/'s} been hacking and sputtering ever since.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "water in their lungs"
-                ]
-            }
-        ],
-        "history": {
-            "reg_death": "m_c died from water-inhalation after falling in the river."
-        }
-    },
-    {
-        "event_id": "mtn_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
+        "event_id": "mtn_injury_mangledtail_anyany1",
+        "biome": ["mountainous"],
+        "camp": ["any"],
+        "season": ["any"],
         "weight": 20,
         "event_text": "m_c's tail was badly injured by falling rocks.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": ["any"],
+            "status": ["any"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "mangled tail"
-                ],
-                "scars": [
-                    "MANTAIL"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["mangled tail"],
+                "scars": ["MANTAIL"]
             }
         ],
         "history": {
@@ -343,210 +69,27 @@
         }
     },
     {
-        "event_id": "mtn_injury_",
-        "biome": [
-            "mountainous"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was grabbed by an eagle, but luckily r_c saves {PRONOUN/m_c/object}! The kit is still left injured from the ordeal.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "claw-wound"
-                ],
-                "scars": [
-                    "TWO"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred as a kit, when an eagle tried to carry {PRONOUN/m_c/object} off.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after an eagle tried to carry {PRONOUN/m_c/object} off."
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "mtn_injury_",
-        "biome": [
-            "mountainous"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was grabbed by a hawk, but luckily r_c saves {PRONOUN/m_c/object}! The kit is still left injured from the ordeal.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "claw-wound"
-                ],
-                "scars": [
-                    "TWO"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred as a kit, when a hawk tried to carry {PRONOUN/m_c/object} off.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after a hawk tried to carry {PRONOUN/m_c/object} off."
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "mtn_injury_",
-        "biome": [
-            "mountainous"
-        ],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c snuck out of camp and returned cold and shivering, frostbite nipping at {PRONOUN/m_c/poss} paws.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "trait": [
-                "daring",
-                "impulsive",
-                "inquisitive",
-                "troublesome"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "frostbite"
-                ],
-                "scars": [
-                    "FROSTSOCK"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred as a kit by frostbite.",
-            "reg_death": "m_c died after they got frostbite sneaking out of camp."
-        }
-    },
-    {
-        "event_id": "mtn_injury_",
-        "biome": [
-            "mountainous"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
+        "event_id": "mtn_injury_brokenbone_anyapprentice1",
+        "biome": ["mountainous"],
+        "camp": ["any"],
+        "season": ["any"],
         "weight": 20,
         "event_text": "m_c couldn't help but try to show off by scaling the tallest cliff {PRONOUN/m_c/subject} could find. {PRONOUN/m_c/poss/CAP} plan backfired when {PRONOUN/m_c/subject} slipped and plummeted to the ground.",
         "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "trait": [
-                "adventurous",
-                "ambitious",
-                "bold",
-                "childish",
-                "confident",
-                "daring",
-                "playful",
-                "troublesome"
-            ]
+            "age": ["adolescent"],
+            "status": ["apprentice"],
+            "trait": ["adventurous", "ambitious", "bold", "childish", "confident", "daring", "playful", "troublesome"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "broken bone"
-                ],
-                "scars": [
-                    "FACE"
-                ]
+                "cats": ["m_c"],
+                "injuries": ["broken bone"],
+                "scars": ["FACE"]
             }
         ],
         "history": {
             "scar": "m_c was scarred after falling from a tall cliff.",
             "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after falling from a tall cliff."
         }
-    }]
+    }    
+]

--- a/resources/dicts/events/injury/plains.json
+++ b/resources/dicts/events/injury/plains.json
@@ -1,188 +1,20 @@
 [
     {
-        "event_id": "pln_injury_",
-        "biome": [
-            "plains"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was grabbed by an eagle, but luckily r_c saves {PRONOUN/m_c/object}! The kit is still left injured from the ordeal.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "claw-wound"
-                ],
-                "scars": [
-                    "TWO"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred as a kit, when an eagle tried to carry {PRONOUN/m_c/object} off.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after an eagle tried to carry {PRONOUN/m_c/object} off."
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "pln_injury_",
-        "biome": [
-            "plains"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was grabbed by a hawk, but luckily r_c saves {PRONOUN/m_c/object}! The kit is still left injured from the ordeal.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "claw-wound"
-                ],
-                "scars": [
-                    "TWO"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred as a kit, when a hawk tried to carry {PRONOUN/m_c/object} off.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after a hawk tried to carry {PRONOUN/m_c/object} off."
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "pln_injury_",
-        "biome": [
-            "plains"
-        ],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c snuck out of camp and returned cold and shivering, frostbite nipping at {PRONOUN/m_c/poss} paws.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "trait": [
-                "daring",
-                "impulsive",
-                "inquisitive",
-                "troublesome"
-            ]
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "frostbite"
-                ],
-                "scars": [
-                    "FROSTMITT"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred as a kit by frostbite.",
-            "reg_death": "m_c died after they got frostbite sneaking out of camp."
-        }
-    },
-    {
-        "event_id": "pln_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
+        "event_id": "pln_injury_brokenbone_anyany1",
+        "biome": ["plains"],
+        "camp": ["any"],
+        "season": ["any"],
         "weight": 20,
         "event_text": "m_c was grabbed and dropped by an eagle, but {PRONOUN/m_c/subject} somehow survived.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": ["any"],
+            "status": ["any"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "broken bone"
-                ],
-                "scars": [
-                    "TWO"
-                ]
+             "cats": ["m_c"],
+             "injuries": ["broken bone"],
+             "scars": ["TWO"]
             }
         ],
         "history": {
@@ -191,237 +23,78 @@
         }
     },
     {
-        "event_id": "pln_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
+        "event_id": "pln_injury_bruisessprain_anyany1",
+        "biome": ["plains"],
+        "camp": ["any"],
+        "season": ["any"],
         "weight": 20,
         "event_text": "m_c was running over the hills, when {PRONOUN/m_c/subject} tripped over {PRONOUN/m_c/poss} own legs and hit the ground hard.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": ["any"],
+            "status": ["any"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "bruises"
-                ]
+             "cats": ["m_c"],
+             "injuries": ["bruises", "sprain"]
             }
         ]
     },
     {
-        "event_id": "pln_injury_",
-        "season": [
-            "newleaf",
-            "leaf-fall"
-        ],
-        "tags": [],
+        "event_id": "pln_injury_sprain_anyany1",
+        "biome": ["plains"],
+        "camp": ["any"],
+        "season": ["any"],
         "weight": 20,
         "event_text": "The ground inside the camp has turned into a muddy mess from the rain. m_c sprains {PRONOUN/m_c/poss} paw while trying to walk through the muck.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": ["any"],
+            "status": ["any"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "sprain"
-                ]
+             "cats": ["m_c"],
+             "injuries": ["sprain"]
             }
         ]
     },
     {
-        "event_id": "pln_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c trips over an unseen rabbit hole, spraining {PRONOUN/m_c/poss} paw.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "sprain"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "pln_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was running over the hills, when {PRONOUN/m_c/subject} tripped over {PRONOUN/m_c/poss} own legs and hit the ground hard.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "sprain"
-                ]
-            }
-        ]
-    },
-    {
-        "event_id": "pln_injury_",
-        "season": [
-            "any"
-        ],
-        "tags": [],
+        "event_id": "pln_injury_sore_anyany1",
+        "biome": ["plains"],
+        "camp": ["any"],
+        "season": ["any"],
         "weight": 20,
         "event_text": "m_c is feeling extremely sore from the long distances {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} run lately.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": ["any"],
+            "status": ["any"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "sore"
-                ]
+             "cats": ["m_c"],
+             "injuries": ["sore"]
             }
         ]
-    },
+    },  
     {
-        "event_id": "pln_injury_",
-        "season": [
-            "any"
-        ],
+        "event_id": "pln_injury_mangledleg_multimultitraidany1",
+        "biome": ["plains"],
+        "camp": ["any"],
+        "season": ["greenleaf", "newleaf", "leaf-fall"],
+        "sub_type": [],
         "tags": [],
-        "weight": 20,
-        "event_text": "m_c survived a vicious eagle attack - with the claw marks to prove it!",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "claw-wound"
-                ],
-                "scars": [
-                    "ONE"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by an eagle.",
-            "reg_death": "m_c died from {PRONOUN/m_c/poss} wounds after fighting an eagle."
-        }
-    },
-    {
-        "event_id": "pln_injury_",
-        "season": [
-            "leaf-fall",
-            "leaf-bare"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was out wandering the territory for a bit too long and came back with frostbite.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "frostbite"
-                ],
-                "scars": [
-                    "FROSTTAIL"
-                ]
-            }
-        ],
-        "history": {
-            "scar": "m_c was scarred by frostbite.",
-            "reg_death": "m_c died after {PRONOUN/m_c/subject} got frostbite."
-        }
-    },
-    {
-        "event_id": "pln_injury_",
-        "season": [
-            "greenleaf",
-            "newleaf",
-            "leaf-fall"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c fell into a river, and inhaled a lot of water before managing to get out. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'ve/'s} been hacking and sputtering ever since.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "water in their lungs"
-                ]
-            }
-        ],
-        "history": {
-            "reg_death": "m_c died from water-inhalation after falling in the river."
-        }
-    },
-    {
-        "event_id": "pln_injury_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
+        "weight": 0,
         "event_text": "Playfully following a butterfly outside the camp, m_c accidentally steps into a rabbit burrow severely injuring {PRONOUN/m_c/poss} leg and letting out a yelp of pain.",
         "m_c": {
-            "age": [],
-            "status": [],
-            "trait": [
-                "childish",
-                "playful"
-            ]
+            "age": ["any"],
+            "status": ["any"],
+            "trait": ["childish", "playful"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "mangled leg"
-                ]
+             "cats": ["m_c"],
+             "injuries": ["mangled leg"],
+             "scars": ["MANLEG"]
             }
         ],
         "history": {
@@ -430,38 +103,21 @@
         }
     },
     {
-        "event_id": "pln_injury_",
-        "biome": [
-            "plains"
-        ],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [],
+        "event_id": "pln_injury_brokenbone_multiany1",
+        "biome": ["plains"],
+        "camp": ["any"],
+        "season": ["greenleaf", "newleaf", "leaf-fall"],
         "weight": 20,
         "event_text": "m_c went out for a walk, but slipped on the ice and broke a bone.",
         "m_c": {
-            "age": [
-                "senior",
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "elder"
-            ],
-            "status": []
+            "age": ["senior", "adolescent", "young adult", "adult", "senior adult"],
+            "status": ["any"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "broken bone"
-                ],
-                "scars": [
-                    "TOETRAP"
-                ]
+             "cats": ["m_c"],
+             "injuries": ["broken bone"],
+             "scars": ["TOETRAP"]
             }
         ],
         "history": {
@@ -470,39 +126,22 @@
         }
     },
     {
-        "event_id": "pln_injury_",
-        "biome": [
-            "plains"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
+        "event_id": "pln_injury_sprain_anymultitraitapprentice1",
+        "biome": ["plains"],
+        "camp": ["any"],
+        "season": ["any"],
         "weight": 20,
         "event_text": "m_c was running around excitedly on patrol, when {PRONOUN/m_c/poss} paw landed right in a rabbit hole, twisting uncomfortably. {PRONOUN/m_c/subject/CAP} limped the whole way home.",
         "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "trait": [
-                "adventurous",
-                "bold",
-                "daring",
-                "playful",
-                "childish"
-            ]
+            "age": ["adolescent"],
+            "status": ["apprentice"],
+            "trait": ["adventurous", "bold", "daring", "playful", "childish"]
         },
         "injury": [
             {
-                "cats": [
-                    "m_c"
-                ],
-                "injuries": [
-                    "sprain"
-                ]
+             "cats": ["m_c"],
+             "injuries": ["sprain"]
             }
         ]
-    }]
+    }
+]

--- a/resources/dicts/events/misc_events/beach.json
+++ b/resources/dicts/events/misc_events/beach.json
@@ -4,7 +4,7 @@
     "biome": ["beach"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["war", "clan_appss"],
+    "tags": ["war", "clan_apps"],
     "weight": 15,
     "event_text": "The apprentices of the Clan are taking special training to learn how to disguise their scents from enemies with kelp and seawater.",
     "m_c": {

--- a/resources/dicts/events/misc_events/beach.json
+++ b/resources/dicts/events/misc_events/beach.json
@@ -1,118 +1,53 @@
 [    
-    {
-        "event_id": "bch_misc",
-        "biome": [
-            "beach"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "war"
-        ],
-        "weight": 20,
-        "event_text": "The apprentices of the Clan are taking special training to learn how to disguise their scents from enemies with kelp and seawater.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        }
-    },
-    {
-        "event_id": "bch_misc",
-        "biome": [
-            "beach"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "As a storm rages across the beach and waves crash upon the shore, m_c is tucked up in the medicine cat den, {PRONOUN/m_c/poss} sleep anything but restful. {PRONOUN/m_c/subject/CAP} {VERB/m_c/keep/keeps} seeing flashes of prophecy_list_sight. {PRONOUN/m_c/subject/CAP} {VERB/m_c/wake/wakes} with a shiver, wondering what {PRONOUN/m_c/poss} dreams mean for the Clan.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ],
-            "skill": [
-                "PROPHET,1"
-            ]
-        }
-    },
-    {
-        "event_id": "bch_misc",
-        "biome": [
-            "beach"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "The things {PRONOUN/m_c/subject} saw today: omen_list_sight... m_c dips a paw in a rockpool, watching the tiny, crawling life inside, and considering what the omens foretell.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ],
-            "skill": [
-                "OMEN,1"
-            ]
-        }
-    },
-    {
-        "event_id": "bch_misc",
-        "biome": [
-            "beach"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "war"
-        ],
-        "weight": 20,
-        "event_text": "m_c sits by the water, contemplating the calm waves that brush {PRONOUN/m_c/poss} paws and wondering why those times are not as peaceful as the tides.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "leader"
-            ],
-            "trait": [
-                "thoughtful",
-                "wise",
-                "righteous"
-            ]
-        }
+  {
+    "event_id": "bch_misc_war_any_apps1",
+    "biome": ["beach"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["war", "clan_appss"],
+    "weight": 15,
+    "event_text": "The apprentices of the Clan are taking special training to learn how to disguise their scents from enemies with kelp and seawater.",
+    "m_c": {
+      "status": ["apprentice"]
     }
+  },
+  {
+    "event_id": "bch_misc_any_prophecymedcatprophet1",
+    "biome": ["beach"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "As a storm rages across the beach and waves crash upon the shore, m_c is tucked up in the medicine cat den, {PRONOUN/m_c/poss} sleep anything but restful. {PRONOUN/m_c/subject/CAP} {VERB/m_c/keep/keeps} seeing flashes of prophecy_list_sight. {PRONOUN/m_c/subject/CAP} {VERB/m_c/wake/wakes} with a shiver, wondering what {PRONOUN/m_c/poss} dreams mean for the Clan.",
+    "m_c": {
+      "status": ["medicine cat", "medicine cat apprentice"],
+      "skill": ["PROPHET,1"]
+    }
+  },
+  {
+    "event_id": "bch_misc_any_omenmedcatomen1",
+    "biome": ["beach"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "The things {PRONOUN/m_c/subject} saw today: omen_list_sight... m_c dips a paw in a rockpool, watching the tiny, crawling life inside, and considering what the omens foretell.",
+    "m_c": {
+      "status": ["medicine cat", "medicine cat apprentice"],
+      "skill": ["PROPHET,1"]
+    }
+  },
+  {
+    "event_id": "bch_misc_war_any_multitraitleader1",
+    "biome": ["beach"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["war"],
+    "weight": 15,
+    "event_text": "m_c sits by the water, contemplating the calm waves that brush {PRONOUN/m_c/poss} paws and wondering why times are not as peaceful as the tides.",
+    "m_c": {
+      "status": ["leader"],
+      "skill": ["MEDIATOR,1"],
+      "trait": ["thoughtful", "wise", "righteous"],
+      "not_trait": ["bloodthirsty", "ambitious"]
+    }
+  }
 ]

--- a/resources/dicts/events/misc_events/beach.json
+++ b/resources/dicts/events/misc_events/beach.json
@@ -20,7 +20,7 @@
     "event_text": "As a storm rages across the beach and waves crash upon the shore, m_c is tucked up in the medicine cat den, {PRONOUN/m_c/poss} sleep anything but restful. {PRONOUN/m_c/subject/CAP} {VERB/m_c/keep/keeps} seeing flashes of prophecy_list_sight. {PRONOUN/m_c/subject/CAP} {VERB/m_c/wake/wakes} with a shiver, wondering what {PRONOUN/m_c/poss} dreams mean for the Clan.",
     "m_c": {
       "status": ["medicine cat", "medicine cat apprentice"],
-      "skill": ["PROPHET,1"]
+      "skill": ["PROPHET,2", "PROPHET,3"]
     }
   },
   {
@@ -32,7 +32,7 @@
     "event_text": "The things {PRONOUN/m_c/subject} saw today: omen_list_sight... m_c dips a paw in a rockpool, watching the tiny, crawling life inside, and considering what the omens foretell.",
     "m_c": {
       "status": ["medicine cat", "medicine cat apprentice"],
-      "skill": ["PROPHET,1"]
+      "skill": ["OMEN,2", "OMEN,3"]
     }
   },
   {

--- a/resources/dicts/events/misc_events/beach.json
+++ b/resources/dicts/events/misc_events/beach.json
@@ -1,49 +1,54 @@
 [    
   {
-    "event_id": "bch_misc_war_any_apps1",
+    "event_id": "bch_misc_war_anyclanapprentice1",
     "biome": ["beach"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["war", "clan_apps"],
+    "sub_type": ["war"],
+    "tags": ["clan_apps"],
     "weight": 15,
     "event_text": "The apprentices of the Clan are taking special training to learn how to disguise their scents from enemies with kelp and seawater.",
     "m_c": {
+      "age": ["any"],
       "status": ["apprentice"]
     }
   },
   {
-    "event_id": "bch_misc_any_prophecymedcatprophet1",
+    "event_id": "bch_misc_anyprophecymedcatprophet1",
     "biome": ["beach"],
     "camp": ["any"],
     "season": ["any"],
     "weight": 10,
     "event_text": "As a storm rages across the beach and waves crash upon the shore, m_c is tucked up in the medicine cat den, {PRONOUN/m_c/poss} sleep anything but restful. {PRONOUN/m_c/subject/CAP} {VERB/m_c/keep/keeps} seeing flashes of prophecy_list_sight. {PRONOUN/m_c/subject/CAP} {VERB/m_c/wake/wakes} with a shiver, wondering what {PRONOUN/m_c/poss} dreams mean for the Clan.",
     "m_c": {
+      "age": ["any"],
       "status": ["medicine cat", "medicine cat apprentice"],
-      "skill": ["PROPHET,2", "PROPHET,3"]
+      "skill": ["PROPHET,2"]
     }
   },
   {
-    "event_id": "bch_misc_any_omenmedcatomen1",
+    "event_id": "bch_misc_anyomenmedcatomen1",
     "biome": ["beach"],
     "camp": ["any"],
     "season": ["any"],
     "weight": 10,
     "event_text": "The things {PRONOUN/m_c/subject} saw today: omen_list_sight... m_c dips a paw in a rockpool, watching the tiny, crawling life inside, and considering what the omens foretell.",
     "m_c": {
+      "age": ["any"],
       "status": ["medicine cat", "medicine cat apprentice"],
-      "skill": ["OMEN,2", "OMEN,3"]
+      "skill": ["OMEN,2"]
     }
   },
   {
-    "event_id": "bch_misc_war_any_multitraitleader1",
+    "event_id": "bch_misc_war_anymultitraitleader1",
     "biome": ["beach"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["war"],
+    "sub_type": ["war"],
     "weight": 15,
     "event_text": "m_c sits by the water, contemplating the calm waves that brush {PRONOUN/m_c/poss} paws and wondering why times are not as peaceful as the tides.",
     "m_c": {
+      "age": ["any"],
       "status": ["leader"],
       "skill": ["MEDIATOR,1"],
       "trait": ["thoughtful", "wise", "righteous"],

--- a/resources/dicts/events/misc_events/forest.json
+++ b/resources/dicts/events/misc_events/forest.json
@@ -1,38 +1,42 @@
 [
   {
-    "event_id": "fst_misc_war_any_apps1",
+    "event_id": "fst_misc_war_anyapps1",
     "biome": ["forest"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["war", "clan_apps"],
+    "sub_type": ["war"],
+    "tags": ["clan_apps"],
     "weight": 15,
     "event_text": "The apprentices of the Clan are taking special training to learn how to land on enemies when jumping from trees.",
     "m_c": {
-        "status": ["apprentice"]
+      "age": ["any"],
+      "status": ["apprentice"]
     }
   },
   {
-    "event_id": "fst_misc_multi_prophecymedcatprophet1",
+    "event_id": "fst_misc_multiprophecymedcatprophet1",
     "biome": ["forest"],
     "camp": ["any"],
-    "season": ["Newleaf", "Greenleaf", "Leaf-fall"],
+    "season": ["newleaf", "greenleaf", "leaf-fall"],
     "weight": 10,
     "event_text": "As a storm rages and the branches of the forest whip around outside, m_c is tucked up in the medicine cat den, {PRONOUN/m_c/poss} sleep anything but restful. {PRONOUN/m_c/subject/CAP} {VERB/m_c/keep/keeps} seeing flashes of prophecy_list_sight. {PRONOUN/m_c/subject/CAP} {VERB/m_c/wake/wakes} with a shiver, wondering what {PRONOUN/m_c/poss} dreams mean for the Clan.",
     "m_c": {
-        "status": ["medicine cat", "medicine cat apprentice"],
-        "skill": ["PROPHET,2", "PROPHET,3"]
+      "age": ["any"],
+      "status": ["medicine cat", "medicine cat apprentice"],
+      "skill": ["PROPHET,2"]
     }
   },
   {
-    "event_id": "fst_misc_multi_omenmedcatomen1",
+    "event_id": "fst_misc_multiomenmedcatomen1",
     "biome": ["forest"],
     "camp": ["any"],
-    "season": ["Newleaf", "Greenleaf", "Leaf-fall"],
+    "season": ["newleaf", "greenleaf", "leaf-fall"],
     "weight": 10,
     "event_text": "The things {PRONOUN/m_c/subject} saw today, omen_list_sight... m_c conceals {PRONOUN/m_c/self} in a hidden alcove under branches that drip all the way to the ground, needing privacy as {PRONOUN/m_c/subject} {VERB/m_c/consider/considers} what these new omens foretell.",
     "m_c": {
-        "status": ["medicine cat", "medicine cat apprentice"],
-        "skill": ["OMEN,2", "OMEN,3"]
+      "age": ["any"],
+      "status": ["medicine cat", "medicine cat apprentice"],
+      "skill": ["OMEN,2"]
     }
   }    
 ]

--- a/resources/dicts/events/misc_events/forest.json
+++ b/resources/dicts/events/misc_events/forest.json
@@ -1,89 +1,38 @@
-[    
-    {
-        "event_id": "fst_misc_",
-        "biome": [
-            "forest"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf",
-            "newleaf",
-            "leaf-fall"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "As a storm rages and the branches of the forest whip around outside, m_c is tucked up in the medicine cat den, {PRONOUN/m_c/poss} sleep anything but restful. {PRONOUN/m_c/subject/CAP} {VERB/m_c/keep/keeps} seeing flashes of prophecy_list_sight. {PRONOUN/m_c/subject/CAP} {VERB/m_c/wake/wakes} with a shiver, wondering what {PRONOUN/m_c/poss} dreams mean for the Clan.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ],
-            "skill": [
-                "PROPHET,1"
-            ]
-        }
-    },
-    {
-        "event_id": "fst_misc_",
-        "biome": [
-            "forest"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf",
-            "newleaf",
-            "leaf-fall"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "The things {PRONOUN/m_c/subject} saw today, omen_list_sight... m_c conceals {PRONOUN/m_c/self} in a hidden alcove under branches that drip all the way to the ground, needing privacy as {PRONOUN/m_c/subject} {VERB/m_c/consider/considers} what these new omens foretell.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ],
-            "skill": [
-                "OMEN,1"
-            ]
-        }
-    },
-    {
-        "event_id": "fst_misc_",
-        "biome": [
-            "forest"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "war"
-        ],
-        "weight": 20,
-        "event_text": "The apprentices of the Clan are taking special training to learn how to land on enemies when jumping from trees.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        }
+[
+  {
+    "event_id": "fst_misc_war_any_apps1",
+    "biome": ["forest"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["war", "clan_appss"],
+    "weight": 15,
+    "event_text": "The apprentices of the Clan are taking special training to learn how to land on enemies when jumping from trees.",
+    "m_c": {
+        "status": ["apprentice"]
     }
+  },
+  {
+    "event_id": "fst_misc_multi_prophecymedcatprophet1",
+    "biome": ["forest"],
+    "camp": ["any"],
+    "season": ["Newleaf", "Greenleaf", "Leaf-fall"],
+    "weight": 10,
+    "event_text": "As a storm rages and the branches of the forest whip around outside, m_c is tucked up in the medicine cat den, {PRONOUN/m_c/poss} sleep anything but restful. {PRONOUN/m_c/subject/CAP} {VERB/m_c/keep/keeps} seeing flashes of prophecy_list_sight. {PRONOUN/m_c/subject/CAP} {VERB/m_c/wake/wakes} with a shiver, wondering what {PRONOUN/m_c/poss} dreams mean for the Clan.",
+    "m_c": {
+        "status": ["medicine cat", "medicine cat apprentice"],
+        "skill": ["PROPHET,1"]
+    }
+  },
+  {
+    "event_id": "fst_misc_multi_omenmedcatomen1",
+    "biome": ["forest"],
+    "camp": ["any"],
+    "season": ["Newleaf", "Greenleaf", "Leaf-fall"],
+    "weight": 10,
+    "event_text": "The things {PRONOUN/m_c/subject} saw today, omen_list_sight... m_c conceals {PRONOUN/m_c/self} in a hidden alcove under branches that drip all the way to the ground, needing privacy as {PRONOUN/m_c/subject} {VERB/m_c/consider/considers} what these new omens foretell.",
+    "m_c": {
+        "status": ["medicine cat", "medicine cat apprentice"],
+        "skill": ["OMEN,1"]
+    }
+  }    
 ]

--- a/resources/dicts/events/misc_events/forest.json
+++ b/resources/dicts/events/misc_events/forest.json
@@ -4,7 +4,7 @@
     "biome": ["forest"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["war", "clan_appss"],
+    "tags": ["war", "clan_apps"],
     "weight": 15,
     "event_text": "The apprentices of the Clan are taking special training to learn how to land on enemies when jumping from trees.",
     "m_c": {

--- a/resources/dicts/events/misc_events/forest.json
+++ b/resources/dicts/events/misc_events/forest.json
@@ -20,7 +20,7 @@
     "event_text": "As a storm rages and the branches of the forest whip around outside, m_c is tucked up in the medicine cat den, {PRONOUN/m_c/poss} sleep anything but restful. {PRONOUN/m_c/subject/CAP} {VERB/m_c/keep/keeps} seeing flashes of prophecy_list_sight. {PRONOUN/m_c/subject/CAP} {VERB/m_c/wake/wakes} with a shiver, wondering what {PRONOUN/m_c/poss} dreams mean for the Clan.",
     "m_c": {
         "status": ["medicine cat", "medicine cat apprentice"],
-        "skill": ["PROPHET,1"]
+        "skill": ["PROPHET,2", "PROPHET,3"]
     }
   },
   {
@@ -32,7 +32,7 @@
     "event_text": "The things {PRONOUN/m_c/subject} saw today, omen_list_sight... m_c conceals {PRONOUN/m_c/self} in a hidden alcove under branches that drip all the way to the ground, needing privacy as {PRONOUN/m_c/subject} {VERB/m_c/consider/considers} what these new omens foretell.",
     "m_c": {
         "status": ["medicine cat", "medicine cat apprentice"],
-        "skill": ["OMEN,1"]
+        "skill": ["OMEN,2", "OMEN,3"]
     }
   }    
 ]

--- a/resources/dicts/events/misc_events/general.json
+++ b/resources/dicts/events/misc_events/general.json
@@ -4,7 +4,7 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["murder_reveal"],
+    "tags": ["murder_reveal", "clan_discovery"],
     "weight": 5,
     "event_text": "m_c can't keep this secret anymore. {PRONOUN/m_c/subject/CAP} {VERB/m_c/request/requests} a Clan meeting, where {PRONOUN/m_c/subject} {VERB/m_c/reveal/reveals} the terrible secret {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} kept; {PRONOUN/m_c/subject} killed mur_c.",
     "m_c": {
@@ -62,7 +62,7 @@
   "biome": ["any"],
   "camp": ["any"],
   "season": ["any"],
-  "tags": ["murder_reveal"],
+  "tags": ["murder_reveal", "clan_discovery"],
   "weight": 5,
   "event_text": "m_c boldly confesses to the entire Clan that {PRONOUN/m_c/subject} killed mur_c. m_c claims that mur_c deserved to pay for what {PRONOUN/mur_c/subject} did.",
   "m_c": {
@@ -90,7 +90,7 @@
   "biome": ["any"],
   "camp": ["any"],
   "season": ["any"],
-  "tags": ["murder_reveal"],
+  "tags": ["murder_reveal", "clan_discovery"],
   "weight": 10,
   "event_text": "m_c's cold eyes don't blink when {PRONOUN/m_c/subject} {VERB/m_c/are/is} accused of murdering mur_c, and only simply states that the Clan is better off without mur_c anyways.",
   "m_c": {
@@ -616,7 +616,11 @@
     "weight": 5,
     "event_text": "m_c and r_c are so cuddled up and cozy in their nest they almost miss the dawn patrol.",
     "m_c": {
+      "age": ["young adult", "adult", "senior adult"],
       "relationship_status": ["mates"]
+    },
+    "r_c": {
+      "age": ["young adult", "adult", "senior adult"]
     },
     "relationships": [
         {
@@ -683,19 +687,25 @@
     ]
   },
   {
-    "event_id": "gen_misc_any_mate5",
+    "event_id": "gen_misc_any_romance1",
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
+    "tags":["romance"],
     "weight": 15,
     "event_text": "m_c and r_c take a late night patrol out of camp to watch the sun rise.",
     "m_c": {
+      "age": ["young adult", "adult", "senior adult"],
+      "relationship_status": ["can_romance"]
+    },
+    "r_c": {
+      "age": ["young adult", "adult", "senior adult"],
       "relationship_status": ["can_romance"]
     },
     "relationships": [
         {
           "mutual": true,
-          "values": ["romantic", "comfort","trust"],
+          "values": ["romantic", "comfort", "trust"],
           "amount": 10
         }
     ]
@@ -705,9 +715,15 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
+    "tags":["romance"],
     "weight": 15,
     "event_text": "m_c and r_c take an early evening patrol out of camp to watch the moon rise.",
     "m_c": {
+      "age": ["young adult", "adult", "senior adult"],
+      "relationship_status": ["can_romance"]
+    },
+    "r_c": {
+      "age": ["young adult", "adult", "senior adult"],
       "relationship_status": ["can_romance"]
     },
     "relationships": [
@@ -726,7 +742,11 @@
     "weight": 5,
     "event_text": "m_c sits still as r_c helps remove some leftover Leaf-bare fluff from the back of {PRONOUN/m_c/poss} neck.",
     "m_c": {
+      "age": ["young adult", "adult", "senior adult","senior"],
       "relationship_status": ["mates"]
+    },
+    "r_c": {
+      "age": ["young adult", "adult", "senior adult", "senior"]
     },
     "relationships": [
         {
@@ -744,7 +764,11 @@
     "weight": 10,
     "event_text": "It's tough working in such extreme heat. m_c and r_c spend their evening relaxing together and cooling down in the shade.",
     "m_c": {
+      "age": ["young adult", "adult", "senior adult","senior"],
       "relationship_status": ["mates"]
+    },
+    "r_c": {
+      "age": ["young adult", "adult", "senior adult", "senior"]
     },
     "relationships": [
         {
@@ -763,7 +787,11 @@
     "event_text": "m_c gives r_c a acc_singular to make up for a bad fight between them.",
     "new_accessory": ["WILD", "PLANT"],
     "m_c": {
+      "age": ["young adult", "adult", "senior adult","senior"],
       "relationship_status": ["mates"]
+    },
+    "r_c": {
+      "age": ["young adult", "adult", "senior adult", "senior"]
     },
     "relationships": [
         {
@@ -782,7 +810,11 @@
     "event_text": "m_c gifts {PRONOUN/m_c/poss} beloved r_c with a acc_singular to wear in {PRONOUN/m_c/poss} pelt.",
     "new_accessory": ["WILD", "PLANT"],
     "m_c": {
+      "age": ["young adult", "adult", "senior adult","senior"],
       "relationship_status": ["mates"]
+    },
+    "r_c": {
+      "age": ["young adult", "adult", "senior adult", "senior"]
     },
     "relationships": [
         {
@@ -801,7 +833,11 @@
     "event_text": "m_c and r_c spend the evening chasing cicadas around camp. m_c keeps a trophy of {PRONOUN/m_c/poss} catch on {PRONOUN/m_c/poss} pelt.",
     "new_accessory": ["CICADA WINGS"],
     "m_c": {
+      "age": ["young adult", "adult", "senior adult","senior"],
       "relationship_status": ["mates"]
+    },
+    "r_c": {
+      "age": ["young adult", "adult", "senior adult", "senior"]
     },
     "relationships": [
         {
@@ -820,7 +856,11 @@
     "event_text": "r_c gives m_c the prettiest fallen leaf {PRONOUN/r_c/subject} can find. m_c wears it with pride.",
     "new_accessory": ["MAPLE LEAF"],
     "m_c": {
+      "age": ["young adult", "adult", "senior adult","senior"],
       "relationship_status": ["mates"]
+    },
+    "r_c": {
+      "age": ["young adult", "adult", "senior adult", "senior"]
     },
     "relationships": [
         {

--- a/resources/dicts/events/misc_events/general.json
+++ b/resources/dicts/events/misc_events/general.json
@@ -4,10 +4,13 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["murder_reveal", "clan_discovery"],
+    "sub_type": ["murder_reveal"],
+    "tags": ["clan_discovery"],
     "weight": 5,
     "event_text": "m_c can't keep this secret anymore. {PRONOUN/m_c/subject/CAP} {VERB/m_c/request/requests} a Clan meeting, where {PRONOUN/m_c/subject} {VERB/m_c/reveal/reveals} the terrible secret {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} kept; {PRONOUN/m_c/subject} killed mur_c.",
     "m_c": {
+      "age": ["any"],
+      "status": ["any"],
       "trait": ["righteous", "bold", "strict"]
     },
     "relationships": [
@@ -26,207 +29,238 @@
         "amount": -30
       }
     ]
-},
-{
-  "event_id": "gen_misc_murderreveal_any2",
-  "biome": ["any"],
-  "camp": ["any"],
-  "season": ["any"],
-  "tags": ["murder_reveal"],
-  "weight": 10,
-  "event_text": "r_c is stunned when {PRONOUN/r_c/subject} {VERB/r_c/discover/discovers} m_c carelessly bragging about killing mur_c to a wandering loner.",
-  "m_c": {
-    "trait": ["oblivious"]
   },
-  "r_c": {
-    "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
-  }
-},
-{
-  "event_id": "gen_misc_murderreveal_any3",
-  "biome": ["any"],
-  "camp": ["any"],
-  "season": ["any"],
-  "tags": ["murder_reveal"],
-  "weight": 10,
-  "event_text": "m_c is truthful when r_c questions {PRONOUN/m_c/object} about mur_c's strange death. m_c claims that mur_c deserved to die after what {PRONOUN/mur_c/subject} did to m_c.",
-  "m_c": {
-    "trait": ["vengeful"]
-  },
-  "r_c": {
-    "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
-  }
-},
-{
-  "event_id": "gen_misc_murderreveal_any4",
-  "biome": ["any"],
-  "camp": ["any"],
-  "season": ["any"],
-  "tags": ["murder_reveal", "clan_discovery"],
-  "weight": 5,
-  "event_text": "m_c boldly confesses to the entire Clan that {PRONOUN/m_c/subject} killed mur_c. m_c claims that mur_c deserved to pay for what {PRONOUN/mur_c/subject} did.",
-  "m_c": {
-    "trait": ["vengeful"]
-  },
-  "relationships": [
-    {
-      "cats_from": ["clan"],
-      "cats_to": ["m_c"],
-      "mutual": false,
-      "values": ["dislike"],
-      "amount": 30
+  {
+    "event_id": "gen_misc_murderreveal_any2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "sub_type": ["murder_reveal"],
+    "weight": 10,
+    "event_text": "r_c is stunned when {PRONOUN/r_c/subject} {VERB/r_c/discover/discovers} m_c carelessly bragging about killing mur_c to a wandering loner.",
+    "m_c": {
+      "age": ["any"],
+      "status": ["any"],
+      "trait": ["oblivious"]
     },
-    {
-      "cats_from": ["clan"],
-      "cats_to": ["m_c"],
-      "mutual": false,
-      "values": ["trust", "respect", "comfort"],
-      "amount": -30
+    "r_c": {
+      "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+      "status": ["any"]
     }
-  ]
-},
-{
-  "event_id": "gen_misc_murderreveal_any5",
-  "biome": ["any"],
-  "camp": ["any"],
-  "season": ["any"],
-  "tags": ["murder_reveal", "clan_discovery"],
-  "weight": 10,
-  "event_text": "m_c's cold eyes don't blink when {PRONOUN/m_c/subject} {VERB/m_c/are/is} accused of murdering mur_c, and only simply states that the Clan is better off without mur_c anyways.",
-  "m_c": {
-    "trait": ["cold"]
-  }
-},
-{
-  "event_id": "gen_misc_murderreveal_any6",
-  "biome": ["any"],
-  "camp": ["any"],
-  "season": ["any"],
-  "tags": ["murder_reveal"],
-  "weight": 10,
-  "event_text": "m_c doesn't change expressions in the slightest when r_c accuses {PRONOUN/m_c/object} of murdering mur_c. Who cares?",
-  "m_c": {
-    "trait": ["cold"]
   },
-  "r_c": {
-    "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
-  }
-},
-{
-  "event_id": "gen_misc_murderreveal_any7",
-  "biome": ["any"],
-  "camp": ["any"],
-  "season": ["any"],
-  "tags": ["murder_reveal"],
-  "weight": 5,
-  "event_text": "r_c avoids m_c at all costs after accidentally witnessing mur_c's murder. r_c knows {PRONOUN/r_c/subject} can't keep it a secret but is terrified of what m_c might do.",
-  "m_c": {
-    "trait": ["bloodthirsty"]
-  },
-  "r_c": {
-    "age": ["kitten","adolescent", "young adult", "adult", "senior adult", "senior"]
-  },
-  "relationships": [
-    {
-      "cats_from": ["r_c"],
-      "cats_to": ["m_c"],
-      "mutual": false,
-      "values": ["dislike"],
-      "amount": 30
+  {
+    "event_id": "gen_misc_murderreveal_any3",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "sub_type": ["murder_reveal"],
+    "weight": 10,
+    "event_text": "m_c is truthful when r_c questions {PRONOUN/m_c/object} about mur_c's strange death. m_c claims that mur_c deserved to die after what {PRONOUN/mur_c/subject} did to m_c.",
+    "m_c": {
+      "age": ["any"],
+      "status": ["any"],
+      "trait": ["vengeful"]
     },
-    {
-      "cats_from": ["clan"],
-      "cats_to": ["m_c"],
-      "mutual": false,
-      "values": ["trust", "respect", "comfort"],
-      "amount": -30
+    "r_c": {
+      "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+      "status": ["any"]
     }
-  ]
-},
-{
-  "event_id": "gen_misc_murderreveal_any8",
-  "biome": ["any"],
-  "camp": ["any"],
-  "season": ["any"],
-  "tags": ["murder_reveal"],
-  "weight": 10,
-  "event_text": "r_c gathers all the courage {PRONOUN/r_c/subject} {VERB/r_c/have/has} and quietly tells m_c {PRONOUN/r_c/subject} {VERB/r_c/know/knows} what {PRONOUN/m_c/subject} did to mur_c. m_c glares menacingly and threatens r_c with the same fate if {PRONOUN/r_c/subject} {VERB/r_c/don't/doesn't} keep {PRONOUN/r_c/poss} mouth shut.",
-  "m_c": {
-    "trait": ["bloodthirsty"]
   },
-  "r_c": {
-    "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
-  }
-},
-{
-  "event_id": "gen_misc_murderreveal_any9",
-  "biome": ["any"],
-  "camp": ["any"],
-  "season": ["any"],
-  "tags": ["murder_reveal"],
-  "weight": 10,
-  "event_text": "m_c laughs menacingly as r_c accuses {PRONOUN/m_c/object} of murdering mur_c. So what if {PRONOUN/m_c/subject} did? What is r_c going to do about it?",
-  "m_c": {
-    "trait": ["bloodthirsty"]
+  {
+    "event_id": "gen_misc_murderreveal_any4",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "sub_type": ["murder_reveal"],
+    "tags": ["clan_discovery"],
+    "weight": 5,
+    "event_text": "m_c boldly confesses to the entire Clan that {PRONOUN/m_c/subject} killed mur_c. m_c claims that mur_c deserved to pay for what {PRONOUN/mur_c/subject} did.",
+    "m_c": {
+      "age": ["any"],
+      "status": ["any"],
+      "trait": ["vengeful"]
+    },
+    "relationships": [
+      {
+        "cats_from": ["clan"],
+        "cats_to": ["m_c"],
+        "mutual": false,
+        "values": ["dislike"],
+        "amount": 30
+      },
+      {
+        "cats_from": ["clan"],
+        "cats_to": ["m_c"],
+        "mutual": false,
+        "values": ["trust", "respect", "comfort"],
+        "amount": -30
+      }
+    ]
   },
-  "r_c": {
-    "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
-  }
-},
-{
-  "event_id": "gen_misc_murderreveal_any10",
-  "biome": ["any"],
-  "camp": ["any"],
-  "season": ["any"],
-  "tags": ["murder_reveal"],
-  "weight": 15,
-  "event_text": "m_c can't keep this secret anymore. When {PRONOUN/m_c/subject} {VERB/m_c/find/finds} {PRONOUN/m_c/self} alone with r_c, {PRONOUN/m_c/subject} {VERB/m_c/tell/tells} the story of mur_c's death.",
-  "m_c": {
-    "relationship_status": ["trust_20"],
-    "trait": ["bloodthirsty"]
-  },
-  "r_c": {
-    "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
-  },
-  "relationships": [
-    {
-      "cats_from": ["r_c"],
-      "cats_to": ["m_c"],
-      "mutual": false,
-      "values": ["trust", "respect", "comfort"],
-      "amount": -30
+  {
+    "event_id": "gen_misc_murderreveal_any5",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "sub_type": ["murder_reveal"],
+    "tags": ["clan_discovery"],
+    "weight": 10,
+    "event_text": "m_c's cold eyes don't blink when {PRONOUN/m_c/subject} {VERB/m_c/are/is} accused of murdering mur_c, and only simply states that the Clan is better off without mur_c anyways.",
+    "m_c": {
+      "age": ["any"],
+      "status": ["any"],
+      "trait": ["cold"]
     }
-  ]
-},
-{
-  "event_id": "gen_misc_murderreveal_any11",
-  "biome": ["any"],
-  "camp": ["any"],
-  "season": ["any"],
-  "tags": ["murder_reveal"],
-  "weight": 15,
-  "event_text": "r_c overheard m_c muttering in {PRONOUN/m_c/poss} sleep, claws slashing at the air. {PRONOUN/m_c/poss/CAP} muttering confirms what r_c always suspected -  m_c was the one responsible for mur_c's death.",
-  "m_c": {
-    "trait": ["bloodthirsty"]
   },
-  "r_c": {
-    "age": ["young adult", "adult", "senior adult", "senior"]
-  },
-  "relationships": [
-    {
-      "cats_from": ["r_c"],
-      "cats_to": ["m_c"],
-      "mutual": false,
-      "values": ["trust", "respect", "comfort"],
-      "amount": -30
+  {
+    "event_id": "gen_misc_murderreveal_any6",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "sub_type": ["murder_reveal"],
+    "weight": 10,
+    "event_text": "m_c doesn't change expressions in the slightest when r_c accuses {PRONOUN/m_c/object} of murdering mur_c. Who cares?",
+    "m_c": {
+      "age": ["any"],
+      "status": ["any"],
+      "trait": ["cold"]
+    },
+    "r_c": {
+      "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+      "status": ["any"]
     }
-  ]
+  },
+  {
+    "event_id": "gen_misc_murderreveal_any7",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "sub_type": ["murder_reveal"],
+    "weight": 5,
+    "event_text": "r_c avoids m_c at all costs after accidentally witnessing mur_c's murder. r_c knows {PRONOUN/r_c/subject} can't keep it a secret but is terrified of what m_c might do.",
+    "m_c": {
+      "age": ["any"],
+      "status": ["any"],
+      "trait": ["bloodthirsty"]
+    },
+    "r_c": {
+      "age": ["young adult", "adult", "senior adult", "senior"],
+      "status": ["any"]
+    },
+    "relationships": [
+      {
+        "cats_from": ["r_c"],
+        "cats_to": ["m_c"],
+        "mutual": false,
+        "values": ["dislike"],
+        "amount": 30
+      },
+      {
+        "cats_from": ["r_c"],
+        "cats_to": ["m_c"],
+        "mutual": false,
+        "values": ["trust", "respect", "comfort"],
+        "amount": -30
+      }
+    ]
+  },
+  {
+    "event_id": "gen_misc_murderreveal_any8",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "sub_type": ["murder_reveal"],
+    "weight": 10,
+    "event_text": "r_c gathers all the courage {PRONOUN/r_c/subject} {VERB/r_c/have/has} and quietly tells m_c {PRONOUN/r_c/subject} {VERB/r_c/know/knows} what {PRONOUN/m_c/subject} did to mur_c. m_c glares menacingly and threatens r_c with the same fate if {PRONOUN/r_c/subject} {VERB/r_c/don't/doesn't} keep {PRONOUN/r_c/poss} mouth shut.",
+    "m_c": {
+      "age": ["any"],
+      "status": ["any"],
+      "trait": ["bloodthirsty"]
+    },
+    "r_c": {
+      "age": ["young adult", "adult", "senior adult", "senior"],
+      "status": ["any"]
+    }
+  },
+  {
+    "event_id": "gen_misc_murderreveal_any9",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "sub_type": ["murder_reveal"],
+    "weight": 10,
+    "event_text": "m_c laughs menacingly as r_c accuses {PRONOUN/m_c/object} of murdering mur_c. So what if {PRONOUN/m_c/subject} did? What is r_c going to do about it?",
+    "m_c": {
+      "age": ["any"],
+      "status": ["any"],
+      "trait": ["bloodthirsty"]
+    },
+    "r_c": {
+      "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+      "status": ["any"]
+    }
+  },
+  {
+    "event_id": "gen_misc_murderreveal_any10",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "sub_type": ["murder_reveal"],
+    "weight": 15,
+    "event_text": "m_c can't keep this secret anymore. When {PRONOUN/m_c/subject} {VERB/m_c/find/finds} {PRONOUN/m_c/self} alone with r_c, {PRONOUN/m_c/subject} {VERB/m_c/tell/tells} the story of mur_c's death.",
+    "m_c": {
+      "age": ["any"],
+      "status": ["any"],
+      "relationship_status": ["trust_20"],
+      "trait": ["bloodthirsty"]
+    },
+    "r_c": {
+      "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+      "status": ["any"]
+    },
+    "relationships": [
+      {
+        "cats_from": ["r_c"],
+        "cats_to": ["m_c"],
+        "mutual": false,
+        "values": ["trust", "respect", "comfort"],
+        "amount": -30
+      }
+    ]
+  },
+  {
+    "event_id": "gen_misc_murderreveal_any11",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "sub_type": ["murder_reveal"],
+    "weight": 15,
+    "event_text": "r_c overheard m_c muttering in {PRONOUN/m_c/poss} sleep, claws slashing at the air. {PRONOUN/m_c/poss/CAP} muttering confirms what r_c always suspected -  m_c was the one responsible for mur_c's death.",
+    "m_c": {
+      "age": ["any"],
+      "status": ["any"],
+      "trait": ["bloodthirsty"]
+    },
+    "r_c": {
+      "age": ["young adult", "adult", "senior adult", "senior"],
+      "status": ["any"]
+    },
+    "relationships": [
+      {
+        "cats_from": ["r_c"],
+        "cats_to": ["m_c"],
+        "mutual": false,
+        "values": ["trust", "respect", "comfort"],
+        "amount": -30
+      }
+    ]
   },
   {
     "event_id": "gen_misc_any_collar_accessory1",
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
+    "sub_type": ["accessory"],
     "weight": 5,
     "event_text":  "m_c disappears for a few days, then returns to camp with a acc_singular around {PRONOUN/m_c/poss} neck.",
     "new_accessory": ["COLLAR"],
@@ -243,7 +277,8 @@
     "weight": 20,
     "event_text": "m_c accidentally trespasses onto o_c's territory.",
     "m_c": {
-        "age": ["adolescent", "young adult", "adult", "senior adult"]
+        "age": ["adolescent", "young adult", "adult", "senior adult"],
+        "status": ["any"]
     },
     "other_clan": {
         "current_rep": ["any"],
@@ -258,7 +293,8 @@
     "weight": 20,
     "event_text": "m_c went for a long walk this morning, deep in thought.",
     "m_c": {
-      "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
+      "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+      "status": ["any"]
     }
   },
   {
@@ -269,7 +305,10 @@
     "weight": 20,
     "event_text": "m_c spends the evening regaling the Clan with stories of story_list.",
     "m_c": {
-        "skill": ["LORE,2", "KIT,1", "STORY,1"]
+      "age": ["any"],
+      "status": ["any"],
+      "skill": ["LORE,1", "KIT,1", "STORY,1"],
+      "not_skill": ["KIT,2", "KIT,3", "KIT,4"]
     }
   },
   {
@@ -278,7 +317,11 @@
     "camp": ["any"],
     "season": ["any"],
     "weight": 20,
-    "event_text": "m_c was trying to fluff up {PRONOUN/m_c/poss} nest when {PRONOUN/m_c/subject} saw a thorn inside of {PRONOUN/m_c/poss} bedding. Another prank, but it could not fool {PRONOUN/m_c/object}!"
+    "event_text": "m_c was trying to fluff up {PRONOUN/m_c/poss} nest when {PRONOUN/m_c/subject} saw a thorn inside of {PRONOUN/m_c/poss} bedding. Another prank, but it could not fool {PRONOUN/m_c/object}!",
+    "m_c": {
+      "age": ["any"],
+      "status": ["any"]
+    }
   },
   {
     "event_id": "gen_misc_any_misc6",
@@ -286,7 +329,11 @@
     "camp": ["any"],
     "season": ["any"],
     "weight": 20,
-    "event_text": "m_c wasn't looking where {PRONOUN/m_c/subject} {VERB/m_c/were/was} going and tripped over a small trunk, but came out of it with only {PRONOUN/m_c/poss} pride bruised."
+    "event_text": "m_c wasn't looking where {PRONOUN/m_c/subject} {VERB/m_c/were/was} going and tripped over a small trunk, but came out of it with only {PRONOUN/m_c/poss} pride bruised.",
+    "m_c": {
+      "age": ["any"],
+      "status": ["any"]
+    }
   },
   {
     "event_id": "gen_misc_any_misc7",
@@ -294,7 +341,11 @@
     "camp": ["any"],
     "season": ["any"],
     "weight": 20,
-    "event_text": "m_c misstepped and slipped from a rock, but landed on {PRONOUN/m_c/poss} feet nimbly, {PRONOUN/m_c/poss} Clanmates commenting on the show of dexterity."
+    "event_text": "m_c misstepped and slipped from a rock, but landed on {PRONOUN/m_c/poss} feet nimbly, {PRONOUN/m_c/poss} Clanmates commenting on the show of dexterity.",
+    "m_c": {
+      "age": ["any"],
+      "status": ["any"]
+    }
   },
   {
     "event_id": "gen_misc_any_misc8",
@@ -302,7 +353,11 @@
     "camp": ["any"],
     "season": ["any"],
     "weight": 20,
-    "event_text": "m_c tossed a snake out of the camp before it could bite someone."
+    "event_text": "m_c tossed a snake out of the camp before it could bite someone.",
+    "m_c": {
+      "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+      "status": ["any"]
+    }
   },
   {
     "event_id": "gen_misc_any_misc9",
@@ -312,10 +367,12 @@
     "weight": 20,
     "event_text": "m_c tries to convince r_c to run away with {PRONOUN/m_c/object}.",
     "m_c": {
-        "age": ["young adult","adult","senior","senior adult"]
+        "age": ["young adult","adult","senior","senior adult"],
+        "status":["any"]
     },
     "r_c": {
-        "age": ["young adult","adult","senior","senior adult"]
+        "age": ["young adult","adult","senior","senior adult"],
+        "status":["any"]
     }
   },
   {
@@ -324,7 +381,11 @@
     "camp": ["any"],
     "season": ["any"],
     "weight": 20,
-    "event_text": "m_c believes {PRONOUN/m_c/subject}'{VERB/m_c/re/s} meant for something greater."
+    "event_text": "m_c believes {PRONOUN/m_c/subject}'{VERB/m_c/re/s} meant for something greater.",
+    "m_c": {
+      "age": ["any"],
+      "status": ["any"]
+    }
   },
   {
     "event_id": "gen_misc_any_misc11",
@@ -332,7 +393,11 @@
     "camp": ["any"],
     "season": ["any"],
     "weight": 20,
-    "event_text": "m_c believes {PRONOUN/m_c/subject} {VERB/m_c/are/is} part of a new prophecy."
+    "event_text": "m_c believes {PRONOUN/m_c/subject} {VERB/m_c/are/is} part of a new prophecy.",
+    "m_c": {
+      "age": ["any"],
+      "status": ["any"]
+    }
   },
   {
     "event_id": "gen_misc_any_misc12",
@@ -340,7 +405,11 @@
     "camp": ["any"],
     "season": ["any"],
     "weight": 10,
-    "event_text": "m_c went missing for a few days."
+    "event_text": "m_c went missing for a few days.",
+    "m_c": {
+      "age": ["any"],
+      "status": ["any"]
+    }
   },
   {
     "event_id": "gen_misc_any_misc13",
@@ -348,7 +417,11 @@
     "camp": ["any"],
     "season": ["any"],
     "weight": 5,
-    "event_text": "m_c is caught breaking the Warrior Code."
+    "event_text": "m_c is caught breaking the Warrior Code.",
+    "m_c": {
+      "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+      "status": ["any"]
+    }
   },
   {
     "event_id": "gen_misc_any_misc14",
@@ -358,7 +431,8 @@
     "weight": 20,
     "event_text": "m_c is caught outside of the Clan's territory.",
     "m_c": {
-        "age": ["adolescent", "young adult","adult","senior","senior adult"]
+        "age": ["adolescent", "young adult","adult","senior","senior adult"],
+        "status": ["any"]
     }
   },
   {
@@ -369,6 +443,8 @@
     "weight": 20,
     "event_text": "m_c considers, as {PRONOUN/m_c/subject} {VERB/m_c/look/looks} out over the Clan, if perhaps this isn't where {PRONOUN/m_c/subject} {VERB/m_c/belong/belongs}.",
     "m_c": {
+      "age": ["any"],
+      "status": ["any"],
       "trait": ["adventurous","daring", "insecure", "nervous"]
     }
   },
@@ -380,6 +456,8 @@
     "weight": 20,
     "event_text": "The world around {PRONOUN/m_c/object} feels smaller lately; m_c looks out at the horizon and yearns for something unnameable.",
     "m_c": {
+      "age": ["any"],
+      "status": ["any"],
       "trait": ["adventurous","daring"]
     }
   },
@@ -392,6 +470,8 @@
     "weight": 5,
     "event_text": "m_c's dreams are filled with flashing teeth and blood-scent. {PRONOUN/m_c/subject/CAP} {VERB/m_c/wake/wakes} up screaming.",
     "m_c": {
+      "age": ["any"],
+      "status": ["any"],
       "skill": ["DARK,0"]
     }
   },
@@ -404,6 +484,8 @@
     "weight": 5,
     "event_text": "m_c thought {PRONOUN/m_c/subject} saw a familar wispy form lingering at the edge of camp, but the ghost disappeared before {PRONOUN/m_c/subject} could be sure.",
     "m_c": {
+      "age": ["any"],
+      "status": ["any"],
       "skill": ["GHOST,0"]
     }
   },
@@ -414,10 +496,7 @@
     "season": ["leaf-fall"],
     "tags": ["clan_kits"],
     "weight": 20,
-    "event_text": "The older cats look fondly upon the kits who are dashing in and out of leaf piles at the edge of camp.",
-    "m_c": {
-      "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
-    }
+    "event_text": "The older cats look fondly upon the kits who are dashing in and out of leaf piles at the edge of camp."
   },
   {
     "event_id": "gen_misc_leafbare_misc1",
@@ -427,10 +506,12 @@
     "weight": 20,
     "event_text": "m_c and r_c begin a small camp snowball fight while on guard duty, eventually getting the whole Clan to join in.",
     "m_c": {
-        "age": ["young adult","adult","senior adult"]
+        "age": ["young adult","adult","senior adult"],
+        "status":["any"]
     },
     "r_c": {
-        "age": ["young adult","adult","senior adult"]
+        "age": ["young adult","adult","senior adult"],
+        "status":["any"]
     },
     "relationships": [
         {
@@ -454,10 +535,12 @@
     "event_text": "m_c encourages r_c to play in the snow with {PRONOUN/m_c/object} during a patrol.",
     "m_c": {
         "age": ["young adult","adult","senior adult"],
+        "status":["any"],
         "trait": ["playful"]
     },
     "r_c":{
-        "age": ["young adult","adult","senior adult"]
+        "age": ["young adult","adult","senior adult"],
+        "status":["any"]
     },
     "relationships": [
         {
@@ -472,31 +555,42 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
+    "sub_type": ["accessory"],
     "weight": 10,
     "event_text": "m_c always seems to have acc_plural stuck in {PRONOUN/m_c/poss} fur.",
-    "new_accessory": ["HERBS","PETALS","DRY HERBS", "RED FEATHERS", "BLUE FEATHERS","JAY FEATHERS"]
+    "new_accessory": ["HERBS","PETALS","DRY HERBS", "RED FEATHERS", "BLUE FEATHERS","JAY FEATHERS"],
+    "m_c":{
+      "age": ["any"],
+      "status": ["any"]
+    }
   },
   {
     "event_id": "gen_misc_any_accessory2",
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
+    "sub_type": ["accessory"],
     "weight": 20,
     "event_text": "r_c finds acc_plural while out on a walk and decides to give them to m_c.",
     "new_accessory": ["WILD","PLANT"],
+    "m_c":{
+      "age": ["any"],
+      "status": ["any"]
+    },
     "r_c": {
-        "age": ["adolescent", "young adult","adult","senior","senior adult"]
+        "age": ["adolescent", "young adult","adult","senior","senior adult"],
+        "status":["any"]
     },
     "relationships": [
         {
-            "mututal": true,
-            "values": ["platonic", "comfort", "trust"],
-            "amount": 5
+          "mututal": true,
+          "values": ["platonic", "comfort", "trust"],
+          "amount": 5
         },
         {
-            "mututal": true,
-            "values": ["dislike"],
-            "amount": -5
+          "mututal": true,
+          "values": ["dislike"],
+          "amount": -5
         }
     ]
   },
@@ -505,25 +599,38 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
+    "sub_type": ["accessory"],
     "weight": 20,
     "event_text": "m_c finds acc_plural while out on a walk and decides to keep them.",
-    "new_accessory": ["WILD","PLANT"]
+    "new_accessory": ["WILD","PLANT"],
+    "m_c":{
+      "age": ["any"],
+      "status": ["any"]
+    }
   },
   {
     "event_id": "gen_misc_any_accessory4",
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["ceremony"],
+    "sub_type": ["ceremony"],
     "weight": 20,
     "event_text": "m_c was given acc_plural as a congratulations, r_c watches from the side with a jealous glint in {PRONOUN/r_c/poss} eyes.",
     "new_accessory": ["WILD", "PLANT"],
+    "m_c":{
+      "age": ["any"],
+      "status": ["any"]
+    },
+    "r_c":{
+      "age": ["any"],
+      "status": ["any"]
+    },
     "relationships": [
         {
-            "cats_from": ["r_c"],
-            "cats_to": ["m_c"],
-            "values": ["platonic","comfort","respect"],
-            "amount": -5
+          "cats_from": ["r_c"],
+          "cats_to": ["m_c"],
+          "values": ["platonic","comfort","respect"],
+          "amount": -5
         }
     ]
   }, 
@@ -532,14 +639,23 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
+    "sub_type": ["accessory"],
     "weight": 20,
     "event_text": "m_c received a present, acc_plural, from r_c and decided to keep it with {PRONOUN/m_c/object} on {PRONOUN/m_c/poss} pelt.",
     "new_accessory": ["WILD", "PLANT"],
+    "m_c":{
+      "age": ["any"],
+      "status": ["any"]
+    },
+    "r_c":{
+      "age": ["any"],
+      "status": ["any"]
+    },
     "relationships": [
         {
-            "mututal": true,
-            "values": ["platonic", "comfort"],
-            "amount": 5
+          "mututal": true,
+          "values": ["platonic", "comfort"],
+          "amount": 5
         }
     ]
   },
@@ -548,20 +664,32 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["ceremony"],
+    "sub_type": ["ceremony"],
     "weight": 20,
     "event_text": "m_c decides to pick something to adorn {PRONOUN/m_c/poss} pelt as celebration.",
-    "new_accessory": ["WILD","PLANT"]
+    "new_accessory": ["WILD","PLANT"],
+    "m_c":{
+      "age": ["any"],
+      "status": ["any"]
+    }
   },
   {
     "event_id": "gen_misc_any_accessory7",
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["ceremony"],
+    "sub_type": ["ceremony"],
     "weight": 20,
     "event_text": "r_c gives m_c something to adorn {PRONOUN/m_c/poss} pelt as congratulations.",
     "new_accessory": ["WILD","PLANT"],
+    "m_c":{
+      "age": ["any"],
+      "status": ["any"]
+    },
+    "r_c":{
+      "age": ["any"],
+      "status": ["any"]
+    },
     "relationships": [
         {
             "mututal": true,
@@ -580,16 +708,21 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["leaf-bare"],
+    "sub_type": ["accessory"],
     "weight": 20,
     "event_text": "m_c found a mysterious acc_singular growing in the frost and decided to wear it.",
-    "new_accessory": ["FORGET ME NOTS", "BLUEBELLS", "POPPY"]
+    "new_accessory": ["FORGET ME NOTS", "BLUEBELLS", "POPPY"],
+    "m_c":{
+      "age": ["any"],
+      "status": ["any"]
+    }
   },
   {
     "event_id": "gen_misc_war_any_any1",
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
-    "weight": 20,
+    "weight": 10,
     "event_text": "The war with o_c is beginning to disrupt the daily lives of c_n, forcing them to adapt to new routines and living situations in order to better defend themselves.",
     "other_clan": {
         "current_rep": ["hostile"],
@@ -617,10 +750,12 @@
     "event_text": "m_c and r_c are so cuddled up and cozy in their nest they almost miss the dawn patrol.",
     "m_c": {
       "age": ["young adult", "adult", "senior adult"],
+      "status": ["any"],
       "relationship_status": ["mates"]
     },
     "r_c": {
-      "age": ["young adult", "adult", "senior adult"]
+      "age": ["young adult", "adult", "senior adult"],
+      "status": ["any"]
     },
     "relationships": [
         {
@@ -639,7 +774,13 @@
     "weight": 10,
     "event_text": "m_c listens bashfully as r_c tells the story of how {PRONOUN/r_c/subject} fell in love with {PRONOUN/r_c/poss} mate to a group of starry-eyed kits.",
     "m_c": {
+      "age": ["any"],
+      "status": ["any"],
       "relationship_status": ["mates"]
+    },
+    "r_c":{
+      "age": ["any"],
+      "status": ["any"]
     },
     "relationships": [
         {
@@ -657,7 +798,13 @@
     "weight": 15,
     "event_text": "m_c watches r_c give an elder the best piece of prey on the pile. {PRONOUN/m_c/subject/CAP} {VERB/m_c/feel/feels} lucky to have such a kind cat as {PRONOUN/m_c/poss} mate.",
     "m_c": {
+      "age": ["any"],
+      "status": ["any"],
       "relationship_status": ["mates"]
+    },
+    "r_c":{
+      "age": ["any"],
+      "status": ["any"]
     },
     "relationships": [
         {
@@ -676,7 +823,13 @@
     "weight": 15,
     "event_text": "m_c and r_c watch the Clan's kits play and daydream about having their own one day.",
     "m_c": {
+      "age": ["any"],
+      "status": ["any"],
       "relationship_status": ["mates"]
+    },
+    "r_c":{
+      "age": ["any"],
+      "status": ["any"]
     },
     "relationships": [
         {
@@ -696,10 +849,12 @@
     "event_text": "m_c and r_c take a late night patrol out of camp to watch the sun rise.",
     "m_c": {
       "age": ["young adult", "adult", "senior adult"],
+      "status": ["any"],
       "relationship_status": ["can_romance"]
     },
     "r_c": {
       "age": ["young adult", "adult", "senior adult"],
+      "status":["any"],
       "relationship_status": ["can_romance"]
     },
     "relationships": [
@@ -720,10 +875,12 @@
     "event_text": "m_c and r_c take an early evening patrol out of camp to watch the moon rise.",
     "m_c": {
       "age": ["young adult", "adult", "senior adult"],
+      "status":["any"],
       "relationship_status": ["can_romance"]
     },
     "r_c": {
       "age": ["young adult", "adult", "senior adult"],
+      "status":["any"],
       "relationship_status": ["can_romance"]
     },
     "relationships": [
@@ -743,10 +900,12 @@
     "event_text": "m_c sits still as r_c helps remove some leftover Leaf-bare fluff from the back of {PRONOUN/m_c/poss} neck.",
     "m_c": {
       "age": ["young adult", "adult", "senior adult","senior"],
+      "status": ["any"],
       "relationship_status": ["mates"]
     },
     "r_c": {
-      "age": ["young adult", "adult", "senior adult", "senior"]
+      "age": ["young adult", "adult", "senior adult", "senior"],
+      "status": ["any"]
     },
     "relationships": [
         {
@@ -765,10 +924,12 @@
     "event_text": "It's tough working in such extreme heat. m_c and r_c spend their evening relaxing together and cooling down in the shade.",
     "m_c": {
       "age": ["young adult", "adult", "senior adult","senior"],
+      "status":["any"],
       "relationship_status": ["mates"]
     },
     "r_c": {
-      "age": ["young adult", "adult", "senior adult", "senior"]
+      "age": ["young adult", "adult", "senior adult", "senior"],
+      "status":["any"]
     },
     "relationships": [
         {
@@ -783,15 +944,18 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
+    "sub_type": ["accessory"],
     "weight": 15,
     "event_text": "m_c gives r_c a acc_singular to make up for a bad fight between them.",
     "new_accessory": ["WILD", "PLANT"],
     "m_c": {
       "age": ["young adult", "adult", "senior adult","senior"],
+      "status":["any"],
       "relationship_status": ["mates"]
     },
     "r_c": {
-      "age": ["young adult", "adult", "senior adult", "senior"]
+      "age": ["young adult", "adult", "senior adult", "senior"],
+      "status":["any"]
     },
     "relationships": [
         {
@@ -806,15 +970,18 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
+    "sub_type": ["accessory"],
     "weight": 5,
     "event_text": "m_c gifts {PRONOUN/m_c/poss} beloved r_c with a acc_singular to wear in {PRONOUN/m_c/poss} pelt.",
     "new_accessory": ["WILD", "PLANT"],
     "m_c": {
       "age": ["young adult", "adult", "senior adult","senior"],
+      "status":["any"],
       "relationship_status": ["mates"]
     },
     "r_c": {
-      "age": ["young adult", "adult", "senior adult", "senior"]
+      "age": ["young adult", "adult", "senior adult", "senior"],
+      "status":["any"]
     },
     "relationships": [
         {
@@ -829,15 +996,18 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["greenleaf"],
+    "sub_type": ["accessory"],
     "weight": 15,
     "event_text": "m_c and r_c spend the evening chasing cicadas around camp. m_c keeps a trophy of {PRONOUN/m_c/poss} catch on {PRONOUN/m_c/poss} pelt.",
     "new_accessory": ["CICADA WINGS"],
     "m_c": {
       "age": ["young adult", "adult", "senior adult","senior"],
+      "status":["any"],
       "relationship_status": ["mates"]
     },
     "r_c": {
-      "age": ["young adult", "adult", "senior adult", "senior"]
+      "age": ["young adult", "adult", "senior adult", "senior"],
+      "status": ["any"]
     },
     "relationships": [
         {
@@ -852,15 +1022,18 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["greenleaf"],
+    "sub_type": ["accessory"],
     "weight": 10,
     "event_text": "r_c gives m_c the prettiest fallen leaf {PRONOUN/r_c/subject} can find. m_c wears it with pride.",
     "new_accessory": ["MAPLE LEAF"],
     "m_c": {
       "age": ["young adult", "adult", "senior adult","senior"],
+      "status":["any"],
       "relationship_status": ["mates"]
     },
     "r_c": {
-      "age": ["young adult", "adult", "senior adult", "senior"]
+      "age": ["young adult", "adult", "senior adult", "senior"],
+      "status":["any"]
     },
     "relationships": [
         {
@@ -914,10 +1087,11 @@
         "weight": 10,
         "event_text": "m_c and r_c try to sneak out of camp, but are caught and returned to the nursery.",
         "m_c": {
-            "age": ["kitten"],
-            "status": ["kitten"]
+          "age":["kitten"],
+          "status": ["kitten"]
         },
         "r_c": {
+          "age":["kitten"],
           "status": ["kitten"]
         },
         "relationships": [
@@ -938,9 +1112,11 @@
         "weight": 15,
         "event_text": "m_c and r_c sneak out of camp to chase butterflies.",
         "m_c": {
-            "status": ["kitten"]
+          "age":["kitten"],
+          "status": ["kitten"]
         },
         "r_c": {
+          "age":["kitten"],
           "status": ["kitten"]
         },
         "relationships": [
@@ -963,6 +1139,7 @@
             "status": ["kitten"]
         },
         "r_c": {
+          "age":["kitten"],
           "status": ["kitten"]
         },
         "relationships": [
@@ -985,6 +1162,7 @@
             "status": ["kitten"]
         },
         "r_c": {
+          "age":["kitten"],
           "status": ["kitten"]
         },
         "relationships": [
@@ -1007,6 +1185,7 @@
             "status": ["kitten"]
         },
         "r_c": {
+          "age":["kitten"],
           "status": ["kitten"]
         },
         "relationships": [
@@ -1029,6 +1208,7 @@
             "status": ["kitten"]
         },
         "r_c": {
+          "age":["kitten"],
           "status": ["kitten"]
         },
         "relationships": [
@@ -1051,6 +1231,7 @@
             "status": ["kitten"]
         },
         "r_c": {
+          "age":["kitten"],
           "status": ["kitten"]
         },
         "relationships": [
@@ -1066,13 +1247,17 @@
         "biome": ["any"],
         "camp": ["any"],
         "season": ["any"],
-        "tags": ["war"],
+        "sub_type": ["war"],
         "weight": 10,
         "event_text": "m_c is being comforted by r_c after having nightmares about the big, bad o_c cats.",
         "m_c": {
             "age": ["kitten"],
             "status": ["kitten"],
             "relationship_status": ["child/parent"]
+        },
+        "r_c":{
+          "age":["any"],
+          "status": ["any"]
         },
         "relationships": [
           {
@@ -1089,6 +1274,7 @@
         "biome": ["any"],
         "camp": ["any"],
         "season": ["any"],
+        "sub_type": ["accessory"],
         "weight": 15,
         "event_text": "m_c was playing with acc_plural earlier, and decides to wear some of them.",
         "new_accessory": ["RED FEATHERS", "BLUE FEATHERS", "JAY FEATHERS"],
@@ -1102,6 +1288,7 @@
         "biome": ["any"],
         "camp": ["any"],
         "season": ["any"],
+        "sub_type": ["accessory"],
         "weight": 15,
         "event_text": "m_c sneaked out of camp, and brought back with them some acc_singular from when {PRONOUN/m_c/poss} fur got snagged in a bush.",
         "new_accessory": ["HOLLY", "JUNIPER"],
@@ -1115,6 +1302,7 @@
         "biome": ["any"],
         "camp": ["any"],
         "season": ["newleaf", "greenleaf"],
+        "sub_type": ["accessory"],
         "weight": 15,
         "event_text": "m_c caught an insect while sneaking outside of the camp and proudly wears its wings as a trophy of {PRONOUN/m_c/poss} journey.",
         "new_accessory": ["MOTH WINGS", "CICADA WINGS"],
@@ -1128,6 +1316,7 @@
       "biome": ["any"],
       "camp": ["any"],
       "season": ["newleaf"],
+      "sub_type": ["accessory"],
       "weight": 15,
       "event_text": "As the wind blows many petals in the camp, m_c picks a few to decorate {PRONOUN/m_c/self}.",
       "new_accessory": ["PETALS"],
@@ -1141,6 +1330,7 @@
         "biome": ["any"],
         "camp": ["any"],
         "season": ["leaf-fall"],
+        "sub_type": ["accessory"],
         "weight": 15,
         "event_text": "As the wind brings many fallen leaves in the camp, m_c picks a acc_singular to decorate {PRONOUN/m_c/poss} pelt.",
         "new_accessory": ["OAK LEAVES", "MAPLE LEAF"],
@@ -1154,6 +1344,7 @@
         "biome": ["any"],
         "camp": ["any"],
         "season": ["any"],
+        "sub_type": ["accessory"],
         "weight": 15,
         "event_text": "m_c is just too cute - r_c gives {PRONOUN/m_c/object} a pretty acc_singular as a gift.",
         "new_accessory": ["WILD", "PLANT"],
@@ -1161,6 +1352,10 @@
           "age": ["kitten"],
           "status": ["kitten"],
           "trait": ["sweet", "polite"]
+        },
+        "r_c":{
+          "age":["any"],
+          "status": ["any"]
         },
         "relationships": [
           {
@@ -1175,6 +1370,7 @@
         "biome": ["any"],
         "camp": ["any"],
         "season": ["any"],
+        "sub_type": ["accessory"],
         "weight": 15,
         "event_text": "r_c gives m_c a pretty acc_singular {PRONOUN/r_c/subject} found while playing.",
         "new_accessory": ["WILD", "PLANT"],
@@ -1183,6 +1379,7 @@
             "status": ["kitten"]
         },
           "r_c": {
+            "age":["kitten"],
             "status": ["kitten"]
           },
         "relationships": [
@@ -1203,6 +1400,7 @@
         "biome": ["any"],
         "camp": ["any"],
         "season": ["any"],
+        "sub_type": ["accessory"],
         "weight": 10,
         "event_text": "m_c starts bringing a pretty acc_singular everywhere {PRONOUN/m_c/subject} {VERB/m_c/go/goes}, and r_c loudly complains that {PRONOUN/r_c/subject} {VERB/r_c/want/wants} one, too.",
         "new_accessory": ["WILD", "PLANT"],
@@ -1211,6 +1409,7 @@
             "status": ["kitten"]
         },
         "r_c": {
+          "age":["kitten"],
           "status": ["kitten"],
           "trait": ["bullying", "impulsive", "attention-seeker"]
         },
@@ -1232,6 +1431,7 @@
         "biome": ["any"],
         "camp": ["any"],
         "season": ["any"],
+        "sub_type": ["accessory"],
         "weight": 10,
         "event_text": "No matter how hard r_c tries, there's always something stuck in m_c's fur.",
         "new_accessory": ["HERBS", "PETALS", "DRY HERBS"],
@@ -1239,6 +1439,10 @@
           "age": ["kitten"],
           "status": ["kitten"],
           "relationship_status": ["child/parent"]
+        },
+        "r_c":{
+          "age":["any"],
+          "status": ["any"]
         }
     },
     {
@@ -1246,6 +1450,7 @@
         "biome": ["any"],
         "camp": ["any"],
         "season": ["any"],
+        "sub_type": ["accessory"],
         "weight": 15,
         "event_text": "m_c finds some acc_singular to wear in {PRONOUN/m_c/poss} fur to impress r_c!",
         "new_accessory": ["WILD", "PLANT"],
@@ -1254,6 +1459,10 @@
             "status": ["kitten"],
             "relationship_status": ["child/parent"],
             "trait": ["attention-seeker", "charming"]
+        },
+        "r_c":{
+          "age":["any"],
+          "status": ["any"]
         }
     },
     {
@@ -1280,7 +1489,8 @@
             "status": ["kitten", "apprentice"]
         },
         "r_c": {
-          "age": ["young adult", "adult", "senior adult", "senior"]
+          "age": ["young adult", "adult", "senior adult", "senior"],
+          "status":["any"]
         },
         "relationships": [
           {
@@ -1478,6 +1688,7 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
+    "sub_type": ["accessory"],
     "weight": 20,
     "event_text": "m_c and r_c were chatting about their day and the chores they finished when r_c mentioned {PRONOUN/r_c/subject} liked the smell of wild fruit. m_c decides to wear acc_plural on {PRONOUN/m_c/poss} pelt, hoping that r_c notices {PRONOUN/m_c/object}.",
     "new_accessory": ["BLUE BERRIES", "HOLLY"],
@@ -1504,6 +1715,7 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
+    "sub_type": ["accessory"],
     "weight": 20,
     "event_text": "m_c, for the umpteenth time, hears r_c complaining about the dry rye stalks underneath {PRONOUN/r_c/poss} paws when {PRONOUN/r_c/subject} {VERB/r_c/finish/finishes} cleaning the elders' den and got an idea. The next day, m_c adorns {PRONOUN/m_c/poss} pelt with acc_plural.",
     "new_accessory": ["RYE STALK"],
@@ -1521,6 +1733,7 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["leaf-bare"],
+    "sub_type": ["accessory"],
     "weight": 20,
     "event_text": "m_c gets dared to hunt outside in the snow alone, and returns with acc_singular in {PRONOUN/m_c/poss} pelt.",
     "new_accessory": ["WILD", "PLANT"],
@@ -1534,6 +1747,7 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
+    "sub_type": ["accessory"],
     "weight": 20,
     "event_text": "m_c is nearly blindsided by r_c as {PRONOUN/r_c/subject} {VERB/r_c/walk/walks} into camp after a long training day, listening to the kit squeak about a type of feather. r_c leads m_c to the nursery, where {PRONOUN/r_c/subject} carefully put acc_plural in m_c's fur.",
     "new_accessory": ["BLUE FEATHERS"],
@@ -1542,12 +1756,13 @@
         "status": ["apprentice"]
     },
     "r_c": {
-        "age": ["kitten"]
+        "age": ["kitten"],
+        "status":["kitten"]
     },
     "relationships": [
         {
             "values": ["platonic","comfort"],
-            "amount": 5
+            "amount": 10
         }
     ]
   },
@@ -1556,7 +1771,7 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
-    "tags":["war"],
+    "sub_type": ["war"],
     "weight": 10,
     "event_text": "m_c is struggling to cope with the violence and chaos of war surrounding {PRONOUN/m_c/object}, finding it difficult to wake up in the morning due to the stress and strain of constant battle training.",
     "m_c": {
@@ -1574,7 +1789,7 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
-    "tags":["war"],
+    "sub_type": ["war"],
     "weight": 20,
     "event_text": "m_c feels like {PRONOUN/m_c/subject} might be growing up too fast in the midst of war.",
     "m_c": {
@@ -1844,12 +2059,13 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["war"],
+    "sub_type": ["war"],
     "weight": 15,
     "event_text": "m_c goes to o_c in an attempt to ease the tension of war between the Clans: it goes well, and o_c begins to draw back from c_n's territory!",
     "m_c": {
+      "age":["any"],
       "status":["mediator", "mediator apprentice"],
-      "skill": ["MEDIATOR,2", "MEDIATOR,3", "MEDIATOR,4"]
+      "skill": ["MEDIATOR,2"]
     },
     "other_clan": {
       "changed": 5
@@ -1860,13 +2076,13 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["war"],
+    "sub_type": ["war"],
     "weight": 20,
     "event_text": "m_c is checking in on every cat in the camp to make sure everyone is staying healthy in the midst of war.",
     "m_c": {
-        "status": [
-            "mediator", "mediator apprentice"],
-        "trait": ["calm", "careful", "insecure", "lonesome", "loyal", "nervous", "compassionate", "faithful", "loving", "responsible", "thoughtful", "wise", "inquisitive", "childish", "playful"]
+      "age":["any"],  
+      "status": ["mediator", "mediator apprentice"],
+      "trait": ["calm", "careful", "insecure", "lonesome", "loyal", "nervous", "compassionate", "faithful", "loving", "responsible", "thoughtful", "wise", "inquisitive", "childish", "playful"]
     },
     "relationships": [
         {
@@ -1883,11 +2099,12 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["war"],
+    "sub_type": ["war"],
     "weight": 15,
     "event_text": "m_c goes to o_c in an attempt to ease the tension of war between the Clans: it doesn't go well, and o_c further advances in c_n's territory.",
     "m_c":{
-        "status":["mediator", "mediator apprentice"]
+      "age":["any"],
+      "status":["mediator", "mediator apprentice"]
     },
     "other_clan": {
       "changed": -5
@@ -1901,7 +2118,8 @@
     "weight": 10,
     "event_text": "m_c pulls r_c to the side, quietly asking {PRONOUN/r_c/object} abou {PRONOUN/r_c/poss} crush on a fellow Clanmate.",
     "m_c":{
-        "status":["mediator", "mediator apprentice"]
+      "age":["any"],
+      "status":["mediator", "mediator apprentice"]
     },
     "r_c": {
       "age": ["young adult", "adult", "senior adult", "senior"],
@@ -1933,27 +2151,28 @@
     "weight": 10,
     "event_text": "m_c spots r_c looking a little bit lonely, and invites {PRONOUN/r_c/object} to watch as {PRONOUN/m_c/subject} {VERB/m_c/perform/performs} {PRONOUN/m_c/poss} duties.",
     "m_c":{
-        "status": ["mediator", "mediator apprentice"]
+      "age":["any"],
+      "status": ["mediator", "mediator apprentice"]
     },
     "r_c": {
       "age": ["kitten"],
       "status": ["kitten"]
     },
     "relationships": [
-        {
-            "cats_from": ["r_c"],
-            "cats_to": ["m_c"],
-            "mutual": false,
-            "values": ["platonic", "trust"],
-            "amount": 10
-          },
-          {
-            "cats_from": ["r_c"],
-            "cats_to": ["m_c"],
-            "mutual": false,
-            "values": ["dislike"],
-            "amount": -5
-          }
+    {
+        "cats_from": ["r_c"],
+        "cats_to": ["m_c"],
+        "mutual": false,
+        "values": ["platonic", "trust"],
+        "amount": 10
+      },
+      {
+        "cats_from": ["r_c"],
+        "cats_to": ["m_c"],
+        "mutual": false,
+        "values": ["dislike"],
+        "amount": -5
+      }
     ]
   },
   {
@@ -1961,15 +2180,17 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["war"],
+    "sub_type": ["war"],
     "weight": 10,
     "event_text": "m_c is giving r_c bad war advice on purpose.",
     "m_c": {
-        "status": ["mediator", "mediator apprentice"],
-        "relationship_status": ["dislike_20"],
-        "trait": ["cunning"]
+      "age":["any"],
+      "status": ["mediator", "mediator apprentice"],
+      "relationship_status": ["dislike_20"],
+      "trait": ["cunning"]
     },
     "r_c": {
+      "age":["any"],
       "status": ["leader"],
       "trait": ["bold", "charismatic","confident", "daring","righteous","ambitious","bloodthirsty","cold","fierce","shameless","strict", "troublesome", "vengeful", "sneaky", "strange"]
     },
@@ -1991,13 +2212,15 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["war"],
+    "sub_type": ["war"],
     "weight": 10,
     "event_text": "m_c is conversing with r_c about ways to potentially end this war without bloodshed.",
     "m_c":{
-        "status": ["mediator", "mediator apprentice"]
+      "age":["any"],
+      "status": ["mediator", "mediator apprentice"]
     },
     "r_c": {
+      "age":["any"],
       "status": ["leader"],
       "trait": ["calm","careful","insecure","lonesome","loyal","nervous","compassionate","faithful","loving","responsible","thoughtful","wise","inquisitive","childish","playful"]
     },
@@ -2016,13 +2239,15 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["war"],
+    "sub_type": ["war"],
     "weight": 10,
     "event_text": "m_c is conversing with r_c about ways to potentially end this war- but not without bloodshed.",
     "m_c":{
-        "status": ["mediator", "mediator apprentice"]
+      "age":["any"],
+      "status": ["mediator", "mediator apprentice"]
     },
     "r_c": {
+      "age":["any"],
       "status": ["leader"],
       "trait": ["bold", "charismatic","confident", "daring","righteous","ambitious","bloodthirsty","cold","fierce","shameless","strict", "troublesome", "vengeful", "sneaky", "strange"]
     },
@@ -2062,7 +2287,7 @@
     "m_c": {
         "age": ["young adult","adult","senior adult","senior"],
         "status": ["medicine cat"],
-        "skill": ["STAR,0", "CLAIRVOYANT,0", "OMEN,0", "DREAM,0"]
+        "skill": ["OMEN,0"]
       },
     "other_clan": {
       "current_rep": ["any"],
@@ -2091,15 +2316,17 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["ceremony"],
+    "sub_type": ["ceremony"],
     "weight": 10,
     "event_text": "r_c presents m_c with acc_plural as a congratulations.",
     "new_accessory": ["WILD", "PLANT"],
     "m_c": {
-        "status": ["medicine cat"]
+      "age":["any"],
+      "status": ["medicine cat"]
     },
     "r_c": {
-        "status": ["medicine cat"]
+      "age":["any"],
+      "status": ["medicine cat"]
     },
     "relationships": [
       {
@@ -2122,14 +2349,16 @@
     "weight": 10,
     "event_text": "m_c speaks to r_c about an omen {PRONOUN/m_c/subject} saw while on patrol recently.",
     "m_c": {
-        "status": ["medicine cat"],
-        "skill": ["OMEN,0"]
+      "age":["any"],
+      "status": ["medicine cat"],
+      "skill": ["OMEN,0"]
       },
     "r_c": {
+      "age":["any"],
       "status": ["leader"]
     }
-},
-{
+  },
+  {
     "event_id": "gen_misc_any_medicinecatmedcatomen1",
     "biome": ["any"],
     "camp": ["any"],
@@ -2137,14 +2366,16 @@
     "weight": 10,
     "event_text": "m_c speaks to r_c about a potential omen and what it means.",
     "m_c": {
-        "status": ["medicine cat"],
-        "skill": ["OMEN,0"]
+      "age":["any"],
+      "status": ["medicine cat"],
+      "skill": ["OMEN,0"]
       },
     "r_c": {
+      "age":["any"],
       "status": ["medicine cat"]
     }
-},
-{
+  },
+  {
     "event_id": "gen_misc_any_medicinecatdream1",
     "biome": ["any"],
     "camp": ["any"],
@@ -2153,24 +2384,26 @@
     "weight": 10,
     "event_text": "m_c walks into the dreams of {PRONOUN/m_c/poss} Clanmates while everyone sleeps.",
     "m_c": {
-        "status": ["medicine cat"],
-        "skill": ["DREAM,2"]
+      "age":["any"],
+      "status": ["medicine cat"],
+      "skill": ["DREAM,2"]
     }
-},
-{
-  "event_id": "gen_misc_any_medicinecatdream2",
-  "biome": ["any"],
-  "camp": ["any"],
-  "season": ["any"],
-  "tags": ["skill_trait_required"],
-  "weight": 10,
-  "event_text": "m_c tosses in {PRONOUN/m_c/poss} sleep as {PRONOUN/m_c/poss} dreamself pads through the thoughts of {PRONOUN/m_c/poss} Clanmates, picking up snippets of dream_list. {PRONOUN/m_c/subject/CAP} slowly {VERB/m_c/blink/blinks} awake, wondering whose dreams {PRONOUN/m_c/subject} walked in.",
-  "m_c": {
+  },
+  {
+    "event_id": "gen_misc_any_medicinecatdream2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["skill_trait_required"],
+    "weight": 10,
+    "event_text": "m_c tosses in {PRONOUN/m_c/poss} sleep as {PRONOUN/m_c/poss} dreamself pads through the thoughts of {PRONOUN/m_c/poss} Clanmates, picking up snippets of dream_list. {PRONOUN/m_c/subject/CAP} slowly {VERB/m_c/blink/blinks} awake, wondering whose dreams {PRONOUN/m_c/subject} walked in.",
+    "m_c": {
+      "age":["any"],
       "status": ["medicine cat apprentice", "medicine cat"], 
       "skill": ["DREAM,2"]
-  }
-},
-{
+    }
+  },
+  {
     "event_id": "gen_misc_any_medicinecatclairvoy1",
     "biome": ["any"],
     "camp": ["any"],
@@ -2179,11 +2412,12 @@
     "weight": 10,
     "event_text": "m_c correctly warns the leader of an ambush, thanks to {PRONOUN/m_c/poss} clairvoyant nature.",
     "m_c": {
-        "status": ["medicine cat"],
-        "skill": ["CLAIRVOYANT,2"]
+      "age":["any"],
+      "status": ["medicine cat"],
+      "skill": ["CLAIRVOYANT,2"]
     }
-},
-{
+  },
+  {
     "event_id": "gen_misc_any_medicinecatprophet1",
     "biome": ["any"],
     "camp": ["any"],
@@ -2191,11 +2425,12 @@
     "weight": 10,
     "event_text": "m_c spends {PRONOUN/m_c/poss} day communing with StarClan, attempting to figure out a recent prophecy.",
     "m_c": {
-        "status":["medicine cat", "medicine cat apprentice"],
-        "skill": ["PROPHET,2"]
+      "age":["any"],
+      "status":["medicine cat", "medicine cat apprentice"],
+      "skill": ["PROPHET,2"]
     }
-},
-{
+  },
+  {
     "event_id": "gen_misc_any_medicinecatelderlore1",
     "biome": ["any"],
     "camp": ["any"],
@@ -2203,31 +2438,32 @@
     "weight": 10,
     "event_text": "m_c has been worried that c_n will lose the knowledge r_c has gained through {PRONOUN/r_c/poss} long life, but by sitting with r_c and discussing {PRONOUN/r_c/poss} experiences, m_c will ensure the lessons learned in the past are never forgotten.",
     "m_c": {
-        "status":["medicine cat"],
-        "skill": ["LORE,0"]
+      "age":["any"],
+      "status":["medicine cat"],
+      "skill": ["LORE,0"]
     },
     "r_c": {
         "age": ["senior"],
         "status": ["elder"]
     }
-},
-
-{
+  },
+  {
     "event_id": "gen_misc_any_medicinecatscandolous1",
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
     "weight": 10,
     "event_text": "m_c was seen loudly bickering with the medicine cat of o_c.",
-    "m_c":{ 
-        "status": ["medicine cat"]
+    "m_c":{
+      "age":["any"],
+      "status": ["medicine cat"]
     },
     "other_clan": {
       "current_rep": ["any"],
       "changed": -5
     }
-},
-{
+  },
+  {
     "event_id": "gen_misc_any_medicinecatscandolous2",
     "biome": ["any"],
     "camp": ["any"],
@@ -2235,72 +2471,77 @@
     "weight": 10,
     "event_text": "m_c was seen talking with a traveling loner healer on the border.",
     "m_c":{
-        "status": ["medicine cat"]
+      "age":["any"],
+      "status": ["medicine cat"]
     }
-},
-{
+  },
+  {
     "event_id": "gen_misc_any_medicinecatwar1",
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["war"],
+    "sub_type": ["war"],
     "weight": 10,
     "event_text": "m_c's knowledge of herbs and healing is being put to the test, with injuries becoming more severe in the midst of war.",
     "m_c": {
-        "status": ["medicine cat", "medicine cat apprentice"]
+      "age":["any"],
+      "status": ["medicine cat", "medicine cat apprentice"]
     }
-},
-{
+  },
+  {
     "event_id": "gen_misc_any_medicinecatwar2",
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["war"],
+    "sub_type": ["war"],
     "weight": 10,
     "event_text": "m_c watches every little thing around {PRONOUN/m_c/object} for any omen that indicates what the Clan should do in the war. The losses weigh heavy on the hearts of every cat.",
     "m_c": {
-        "status": ["medicine cat apprentice", "medicine cat"],
-        "skill": ["OMEN,0"]
+      "age":["any"],
+      "status": ["medicine cat apprentice", "medicine cat"],
+      "skill": ["OMEN,1"]
     }
-},
-{
+  },
+  {
     "event_id": "gen_misc_any_medicinecatwar3",
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["war"],
+    "sub_type": ["war"],
     "weight": 10,
     "event_text": "m_c preps battle herbs into small bundles to rush to the battlefield in case of severe injuries.",
     "m_c":{
-        "status": ["medicine cat apprentice", "medicine cat"]
+      "age":["any"],
+      "status": ["medicine cat apprentice", "medicine cat"]
     }
-},
-{
-  "event_id": "gen_misc_any_medcatwar4",
-  "biome": ["any"],
-  "camp": ["any"],
-  "season": ["any"],
-  "tags": ["war"],
-  "weight": 10,
-  "event_text": "c_n is in a badly need of herbs, and m_c knows it, but can't bring {PRONOUN/m_c/self} to leave {PRONOUN/m_c/poss} patients' side.",
-  "m_c": {
+  },
+  {
+    "event_id": "gen_misc_any_medcatwar4",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "sub_type": ["war"],
+    "weight": 10,
+    "event_text": "c_n is in a badly need of herbs, and m_c knows it, but can't bring {PRONOUN/m_c/self} to leave {PRONOUN/m_c/poss} patients' side.",
+    "m_c": {
+      "age":["any"],
       "status": ["medicine cat", "medicine cat apprentice"]
-  }
-},
-{
+    }
+  },
+  {
     "event_id": "gen_misc_leafbare_medicinecatwar1",
     "biome": ["any"],
     "camp": ["any"],
     "season": ["leafbare"],
-    "tags": ["war"],
+    "sub_type": ["war"],
     "weight": 10,
     "event_text":"m_c hopes to find the herbs that c_n needs in the war, and goes to look for them even in this leafbare's harsh weather.",
     "m_c": {
-        "status": ["medicine cat apprentice", "medicine cat"]
+      "age":["any"],
+      "status": ["medicine cat apprentice", "medicine cat"]
     }
-},
-
-{
+  },
+  {
     "event_id": "gen_misc_any_medicinecatmedcatapp1",
     "biome": ["any"],
     "camp": ["any"],
@@ -2308,9 +2549,11 @@
     "weight": 5,
     "event_text": "m_c is getting increasingly annoyed with r_c because {PRONOUN/r_c/subject} {VERB/r_c/keep/keeps} bothering {PRONOUN/m_c/object} about the most trivial of wounds and aches.",
     "m_c":{
-        "status":["medicine cat"]
+      "age":["any"],
+      "status":["medicine cat"]
     },
     "r_c": {
+      "age":["any"],
       "status": ["medicine cat apprentice"]
     },
     "relationships": [
@@ -2331,8 +2574,8 @@
     "weight": 20,
     "event_text": "m_c is brought back to camp after wandering off.",
     "m_c": {
-        "status":["elder"],
-      "age": ["senior"]
+      "age": ["senior"],
+      "status":["elder"]
     }
   },
   {
@@ -2343,7 +2586,8 @@
     "weight": 20,
     "event_text": "m_c awakens with multiple objects stacked on {PRONOUN/m_c/object}, and the sound of giggling cats in the distance.",
     "m_c": {
-        "status":["elder"]
+      "age": ["any"],
+      "status":["elder"]
     }
   },
   {
@@ -2354,11 +2598,13 @@
     "weight": 15,
     "event_text": "m_c speaks to r_c about how to better defend the camp.",
     "m_c": {
-        "status":["elder"],
-        "skill": ["INSIGHTFUL,1"]
+      "age":["any"],
+      "status":["elder"],
+      "skill": ["INSIGHTFUL,1"]
     },
     "r_c": {
-        "status": ["leader"]
+      "age":["any"],
+      "status": ["leader"]
     }
   },
   {
@@ -2369,7 +2615,8 @@
     "weight": 10,
     "event_text": "m_c helps reinforce the dens in the camp while the rest of the camp is on patrol.",
     "m_c": {
-        "status":["elder"],
+      "age":["any"],
+      "status":["elder"],
       "skill": ["CAMP,2"]
     }
   },
@@ -2381,7 +2628,8 @@
     "weight": 10,
     "event_text": "m_c places small feathers and shining stones near the nest of each Clanmate while they're on patrol.",
     "m_c": {
-        "status":["elder"],
+      "age":["any"],
+      "status":["elder"],
       "skill": ["CAMP,2"]
     }
   },
@@ -2393,7 +2641,8 @@
     "weight": 15,
     "event_text": "m_c keeps an eye on the camp while the warriors are on patrol.",
     "m_c": {
-        "status":["elder"],
+      "age":["any"],
+      "status":["elder"],
       "skill": ["CAMP,3"]
     }
   },
@@ -2405,31 +2654,32 @@
     "weight": 10,
     "event_text": "m_c calls the younger cats to {PRONOUN/m_c/poss} den to tell stories of the Clan's past.",
     "m_c": {
-        "status":["elder"],
+      "age":["any"],
+      "status":["elder"],
       "skill": ["STORY,1"]
     }
   },
   {
     "event_id": "gen_misc_any_storyelder2",
-        "biome": ["any"],
-        "camp": ["any"],
-        "season": ["any"],
-        "tags": ["clan_kits"],
-        "weight": 15,
-        "event_text": "m_c calls out to some eager kits, and after they have situated themselves in front of m_c, {PRONOUN/m_c/subject} {VERB/m_c/start/starts} telling the kits a thrilling story of times long past.",
-        "m_c": {
-          "age": ["senior", "adolescent","young adult", "adult","senior adult"],
-          "skill": ["STORY,1","LORE,2"]
-        },
-        "relationships": [
-          {
-            "cats_from": ["clan"],
-            "cats_to": ["m_c"],
-            "mutual": false,
-            "values": ["comfort","respect"],
-            "amount": 10
-          }
-        ]
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["clan_kits"],
+    "weight": 15,
+    "event_text": "m_c calls out to some eager kits, and after they have situated themselves in front of m_c, {PRONOUN/m_c/subject} {VERB/m_c/start/starts} telling the kits a thrilling story of times long past.",
+    "m_c": {
+      "age": ["senior", "adolescent","young adult", "adult","senior adult"],
+      "skill": ["STORY,1","LORE,2"]
+    },
+    "relationships": [
+      {
+        "cats_from": ["clan"],
+        "cats_to": ["m_c"],
+        "mutual": false,
+        "values": ["comfort","respect"],
+        "amount": 10
+      }
+    ]
   },
   {
     "event_id": "gen_misc_any_retiredeputy1",
@@ -2439,12 +2689,10 @@
     "weight": 15,
     "event_text": "m_c thinks about retiring from being deputy.",
     "m_c": {
-        "status": ["deputy"],
-        "age": ["senior adult", "senior"]
+      "age": ["senior adult", "senior"],
+      "status": ["deputy"]
     }
   },
-
-
   {
     "event_id": "gen_misc_any_otherclandeputy1",
     "biome": ["any"],
@@ -2453,7 +2701,8 @@
     "weight": 10,
     "event_text": "m_c travels to o_c to bring them an important message.",
     "m_c":{
-        "status": ["medicine cat", "deputy"]
+      "age":["any"],
+      "status": ["medicine cat", "deputy"]
     },
     "other_clan": {
       "current_rep": ["any"],
@@ -2468,7 +2717,8 @@
     "weight": 10,
     "event_text": "m_c travels to the other Clans to bring them an important message.",
     "m_c":{
-        "status": ["medicine cat", "deputy"]
+      "age":["any"],
+      "status": ["medicine cat", "deputy"]
     },
     "other_clan": {
       "current_rep": ["any"],
@@ -2480,11 +2730,12 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["war"],
+    "sub_type": ["war"],
     "weight": 10,
     "event_text": "As the deputy, m_c is doing {PRONOUN/m_c/poss} best to prepare for leadership in the case that the worst happens.",
     "m_c":{
-        "status": ["deputy"]
+      "age":["any"],
+      "status": ["deputy"]
     }
   },
   {
@@ -2492,14 +2743,16 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["war"],
+    "sub_type": ["war"],
     "weight": 5,
     "event_text": "m_c is struggling to accept the fact that {PRONOUN/m_c/subject} may have to step up as leader if r_c loses {PRONOUN/r_c/poss} last life.",
     "m_c": {
-        "status": ["deputy"],
-        "trait": ["insecure","lonesome", "nervous"]
+      "age":["any"],
+      "status": ["deputy"],
+      "trait": ["insecure","lonesome", "nervous"]
       },
       "r_c": {
+        "age":["any"],
         "status": ["leader"]
       }
   },
@@ -2508,14 +2761,16 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["war"],
+     "sub_type": ["war"],
     "weight": 10,
     "event_text": "m_c is struggling to accept the fact that {PRONOUN/m_c/subject} may have to step up as leader if r_c loses {PRONOUN/r_c/poss} last life. How could {PRONOUN/m_c/subject} {VERB/m_c/go/goes} on without {PRONOUN/m_c/poss} beloved leader? How difficult will it to be to lead in {PRONOUN/r_c/poss} stead?",
     "m_c": {
-        "status": ["deputy"],
-        "trait": ["insecure","lonesome", "nervous"]
+      "age":["any"],
+      "status": ["deputy"],
+      "trait": ["insecure","lonesome", "nervous"]
       },
       "r_c": {
+        "age":["any"],
         "status": ["leader"]
       },
     "relationships": [
@@ -2533,14 +2788,16 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["war"],
+     "sub_type": ["war"],
     "weight": 10,
     "event_text": "m_c is heavily relying on the tactical advice and experience of the elders, namely r_c.",
     "m_c": {
-        "status": ["deputy"],
-        "trait": ["insecure","lonesome", "nervous"]
+      "age":["any"],
+      "status": ["deputy"],
+      "trait": ["insecure","lonesome", "nervous"]
       },
       "r_c": {
+        "age":["any"],
         "status": ["elder"],
         "skill": ["INSIGHTFUL,1","TEACHER,3", "CLEVER,3", "CAMP,3"]
       },
@@ -2563,7 +2820,8 @@
     "weight": 10,
     "event_text": "m_c thinks about retiring.",
     "m_c":{
-      "status":["leader"]
+      "age":["any"],
+      "status": ["leader"]
     }
   },
   {
@@ -2575,6 +2833,7 @@
     "weight": 10,
     "event_text": "m_c confesses {PRONOUN/m_c/subject} {VERB/m_c/don't/doesn't} have many lives left.",
     "m_c":{
+      "age":["any"],
       "status":["leader"]
     }
   },
@@ -2586,7 +2845,8 @@
     "weight": 10,
     "event_text": "m_c feels as though the responsibility of leadership is crushing {PRONOUN/m_c/object}.",
     "m_c":{
-      "status":["leader"]
+      "age":["any"],
+      "status": ["leader"]
     }
   },
   {
@@ -2597,6 +2857,7 @@
     "weight": 20,
     "event_text": "m_c calls a Clan meeting to give an important announcement.",
     "m_c":{
+      "age":["any"],
       "status":["leader"]
     }
   },
@@ -2605,38 +2866,41 @@
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["war"],
+     "sub_type": ["war"],
     "weight": 10,
     "event_text": "m_c feels burdened with the weight of {PRONOUN/m_c/poss} decisions, knowing that every choice they make could mean the difference between victory and defeat.",
     "m_c":{
+      "age":["any"],
       "status":["leader"]
     }
-},
-{
+  },
+  {
     "event_id": "gen_misc_any_warleader2",
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["war"],
+     "sub_type": ["war"],
     "weight": 10,
     "event_text": "m_c's relationships with {PRONOUN/m_c/poss} Clanmates are strained, with some questioning {PRONOUN/m_c/poss} decisions and others relying on {PRONOUN/m_c/object} more heavily than ever.",
     "m_c":{
+      "age":["any"],
       "status":["leader"]
     }
-},
-{
+  },
+  {
     "event_id": "gen_misc_any_warleader3",
     "biome": ["any"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["war"],
+     "sub_type": ["war"],
     "weight": 10,
     "event_text": "m_c is forced to be a symbol of strength and unity for {PRONOUN/m_c/poss} Clan, even in the face of {PRONOUN/m_c/poss} own doubts and fears.",
     "m_c":{
+      "age":["any"],
       "status": ["leader"]
     }
-},
-{
+  },
+  {
     "event_id": "gen_misc_any_leaderapprentice1",
     "biome": ["any"],
     "camp": ["any"],
@@ -2644,9 +2908,10 @@
     "weight": 20,
     "event_text": "m_c assesses r_c's progress.",
     "m_c":{
+      "age":["any"],
       "status":["leader"]
     },
-    "r_c": {
+    "r_c": {"age":["any"],
       "status": ["apprentice", "mediator apprentice", "medicine cat apprentice"]
     }
   }

--- a/resources/dicts/events/misc_events/general.json
+++ b/resources/dicts/events/misc_events/general.json
@@ -1,5659 +1,2613 @@
-[    
+[
+  {
+    "event_id": "gen_misc_murderreveal_any1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["murder_reveal"],
+    "weight": 5,
+    "event_text": "m_c can't keep this secret anymore. {PRONOUN/m_c/subject/CAP} {VERB/m_c/request/requests} a Clan meeting, where {PRONOUN/m_c/subject} {VERB/m_c/reveal/reveals} the terrible secret {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} kept; {PRONOUN/m_c/subject} killed mur_c.",
+    "m_c": {
+      "trait": ["righteous", "bold", "strict"]
+    },
+    "relationships": [
+      {
+        "cats_from": ["clan"],
+        "cats_to": ["m_c"],
+        "mutual": false,
+        "values": ["dislike"],
+        "amount": 30
+      },
+      {
+        "cats_from": ["clan"],
+        "cats_to": ["m_c"],
+        "mutual": false,
+        "values": ["trust", "respect", "comfort"],
+        "amount": -30
+      }
+    ]
+},
+{
+  "event_id": "gen_misc_murderreveal_any2",
+  "biome": ["any"],
+  "camp": ["any"],
+  "season": ["any"],
+  "tags": ["murder_reveal"],
+  "weight": 10,
+  "event_text": "r_c is stunned when {PRONOUN/r_c/subject} {VERB/r_c/discover/discovers} m_c carelessly bragging about killing mur_c to a wandering loner.",
+  "m_c": {
+    "trait": ["oblivious"]
+  },
+  "r_c": {
+    "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
+  }
+},
+{
+  "event_id": "gen_misc_murderreveal_any3",
+  "biome": ["any"],
+  "camp": ["any"],
+  "season": ["any"],
+  "tags": ["murder_reveal"],
+  "weight": 10,
+  "event_text": "m_c is truthful when r_c questions {PRONOUN/m_c/object} about mur_c's strange death. m_c claims that mur_c deserved to die after what {PRONOUN/mur_c/subject} did to m_c.",
+  "m_c": {
+    "trait": ["vengeful"]
+  },
+  "r_c": {
+    "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
+  }
+},
+{
+  "event_id": "gen_misc_murderreveal_any4",
+  "biome": ["any"],
+  "camp": ["any"],
+  "season": ["any"],
+  "tags": ["murder_reveal"],
+  "weight": 5,
+  "event_text": "m_c boldly confesses to the entire Clan that {PRONOUN/m_c/subject} killed mur_c. m_c claims that mur_c deserved to pay for what {PRONOUN/mur_c/subject} did.",
+  "m_c": {
+    "trait": ["vengeful"]
+  },
+  "relationships": [
     {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c visits the other medicine cats.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ]
+      "cats_from": ["clan"],
+      "cats_to": ["m_c"],
+      "mutual": false,
+      "values": ["dislike"],
+      "amount": 30
+    },
+    {
+      "cats_from": ["clan"],
+      "cats_to": ["m_c"],
+      "mutual": false,
+      "values": ["trust", "respect", "comfort"],
+      "amount": -30
+    }
+  ]
+},
+{
+  "event_id": "gen_misc_murderreveal_any5",
+  "biome": ["any"],
+  "camp": ["any"],
+  "season": ["any"],
+  "tags": ["murder_reveal"],
+  "weight": 10,
+  "event_text": "m_c's cold eyes don't blink when {PRONOUN/m_c/subject} {VERB/m_c/are/is} accused of murdering mur_c, and only simply states that the Clan is better off without mur_c anyways.",
+  "m_c": {
+    "trait": ["cold"]
+  }
+},
+{
+  "event_id": "gen_misc_murderreveal_any6",
+  "biome": ["any"],
+  "camp": ["any"],
+  "season": ["any"],
+  "tags": ["murder_reveal"],
+  "weight": 10,
+  "event_text": "m_c doesn't change expressions in the slightest when r_c accuses {PRONOUN/m_c/object} of murdering mur_c. Who cares?",
+  "m_c": {
+    "trait": ["cold"]
+  },
+  "r_c": {
+    "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
+  }
+},
+{
+  "event_id": "gen_misc_murderreveal_any7",
+  "biome": ["any"],
+  "camp": ["any"],
+  "season": ["any"],
+  "tags": ["murder_reveal"],
+  "weight": 5,
+  "event_text": "r_c avoids m_c at all costs after accidentally witnessing mur_c's murder. r_c knows {PRONOUN/r_c/subject} can't keep it a secret but is terrified of what m_c might do.",
+  "m_c": {
+    "trait": ["bloodthirsty"]
+  },
+  "r_c": {
+    "age": ["kitten","adolescent", "young adult", "adult", "senior adult", "senior"]
+  },
+  "relationships": [
+    {
+      "cats_from": ["r_c"],
+      "cats_to": ["m_c"],
+      "mutual": false,
+      "values": ["dislike"],
+      "amount": 30
+    },
+    {
+      "cats_from": ["clan"],
+      "cats_to": ["m_c"],
+      "mutual": false,
+      "values": ["trust", "respect", "comfort"],
+      "amount": -30
+    }
+  ]
+},
+{
+  "event_id": "gen_misc_murderreveal_any8",
+  "biome": ["any"],
+  "camp": ["any"],
+  "season": ["any"],
+  "tags": ["murder_reveal"],
+  "weight": 10,
+  "event_text": "r_c gathers all the courage {PRONOUN/r_c/subject} {VERB/r_c/have/has} and quietly tells m_c {PRONOUN/r_c/subject} {VERB/r_c/know/knows} what {PRONOUN/m_c/subject} did to mur_c. m_c glares menacingly and threatens r_c with the same fate if {PRONOUN/r_c/subject} {VERB/r_c/don't/doesn't} keep {PRONOUN/r_c/poss} mouth shut.",
+  "m_c": {
+    "trait": ["bloodthirsty"]
+  },
+  "r_c": {
+    "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
+  }
+},
+{
+  "event_id": "gen_misc_murderreveal_any9",
+  "biome": ["any"],
+  "camp": ["any"],
+  "season": ["any"],
+  "tags": ["murder_reveal"],
+  "weight": 10,
+  "event_text": "m_c laughs menacingly as r_c accuses {PRONOUN/m_c/object} of murdering mur_c. So what if {PRONOUN/m_c/subject} did? What is r_c going to do about it?",
+  "m_c": {
+    "trait": ["bloodthirsty"]
+  },
+  "r_c": {
+    "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
+  }
+},
+{
+  "event_id": "gen_misc_murderreveal_any10",
+  "biome": ["any"],
+  "camp": ["any"],
+  "season": ["any"],
+  "tags": ["murder_reveal"],
+  "weight": 15,
+  "event_text": "m_c can't keep this secret anymore. When {PRONOUN/m_c/subject} {VERB/m_c/find/finds} {PRONOUN/m_c/self} alone with r_c, {PRONOUN/m_c/subject} {VERB/m_c/tell/tells} the story of mur_c's death.",
+  "m_c": {
+    "relationship_status": ["trust_20"],
+    "trait": ["bloodthirsty"]
+  },
+  "r_c": {
+    "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
+  },
+  "relationships": [
+    {
+      "cats_from": ["r_c"],
+      "cats_to": ["m_c"],
+      "mutual": false,
+      "values": ["trust", "respect", "comfort"],
+      "amount": -30
+    }
+  ]
+},
+{
+  "event_id": "gen_misc_murderreveal_any11",
+  "biome": ["any"],
+  "camp": ["any"],
+  "season": ["any"],
+  "tags": ["murder_reveal"],
+  "weight": 15,
+  "event_text": "r_c overheard m_c muttering in {PRONOUN/m_c/poss} sleep, claws slashing at the air. {PRONOUN/m_c/poss/CAP} muttering confirms what r_c always suspected -  m_c was the one responsible for mur_c's death.",
+  "m_c": {
+    "trait": ["bloodthirsty"]
+  },
+  "r_c": {
+    "age": ["young adult", "adult", "senior adult", "senior"]
+  },
+  "relationships": [
+    {
+      "cats_from": ["r_c"],
+      "cats_to": ["m_c"],
+      "mutual": false,
+      "values": ["trust", "respect", "comfort"],
+      "amount": -30
+    }
+  ]
+  },
+  {
+    "event_id": "gen_misc_any_collar_accessory1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 5,
+    "event_text":  "m_c disappears for a few days, then returns to camp with a acc_singular around {PRONOUN/m_c/poss} neck.",
+    "new_accessory": ["COLLAR"],
+    "m_c": {
+        "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+        "status": ["apprentice", "warrior", "deputy", "leader", "medicine cat", "elder", "mediator"]
+    }
+  }, 
+  {
+    "event_id": "gen_misc_any_misc1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "m_c accidentally trespasses onto o_c's territory.",
+    "m_c": {
+        "age": ["adolescent", "young adult", "adult", "senior adult"]
+    },
+    "other_clan": {
+        "current_rep": ["any"],
+        "changed": -5
+    }
+  },
+  {
+    "event_id": "gen_misc_any_misc2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "m_c went for a long walk this morning, deep in thought.",
+    "m_c": {
+      "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
+    }
+  },
+  {
+    "event_id": "gen_misc_any_misc4",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "m_c spends the evening regaling the Clan with stories of story_list.",
+    "m_c": {
+        "skill": ["LORE,2", "KIT,1", "STORY,1"]
+    }
+  },
+  {
+    "event_id": "gen_misc_any_misc5",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "m_c was trying to fluff up {PRONOUN/m_c/poss} nest when {PRONOUN/m_c/subject} saw a thorn inside of {PRONOUN/m_c/poss} bedding. Another prank, but it could not fool {PRONOUN/m_c/object}!"
+  },
+  {
+    "event_id": "gen_misc_any_misc6",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "m_c wasn't looking where {PRONOUN/m_c/subject} {VERB/m_c/were/was} going and tripped over a small trunk, but came out of it with only {PRONOUN/m_c/poss} pride bruised."
+  },
+  {
+    "event_id": "gen_misc_any_misc7",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "m_c misstepped and slipped from a rock, but landed on {PRONOUN/m_c/poss} feet nimbly, {PRONOUN/m_c/poss} Clanmates commenting on the show of dexterity."
+  },
+  {
+    "event_id": "gen_misc_any_misc8",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "m_c tossed a snake out of the camp before it could bite someone."
+  },
+  {
+    "event_id": "gen_misc_any_misc9",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "m_c tries to convince r_c to run away with {PRONOUN/m_c/object}.",
+    "m_c": {
+        "age": ["young adult","adult","senior","senior adult"]
+    },
+    "r_c": {
+        "age": ["young adult","adult","senior","senior adult"]
+    }
+  },
+  {
+    "event_id": "gen_misc_any_misc10",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "m_c believes {PRONOUN/m_c/subject}'{VERB/m_c/re/s} meant for something greater."
+  },
+  {
+    "event_id": "gen_misc_any_misc11",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "m_c believes {PRONOUN/m_c/subject} {VERB/m_c/are/is} part of a new prophecy."
+  },
+  {
+    "event_id": "gen_misc_any_misc12",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "m_c went missing for a few days."
+  },
+  {
+    "event_id": "gen_misc_any_misc13",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 5,
+    "event_text": "m_c is caught breaking the Warrior Code."
+  },
+  {
+    "event_id": "gen_misc_any_misc14",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "m_c is caught outside of the Clan's territory.",
+    "m_c": {
+        "age": ["adolescent", "young adult","adult","senior","senior adult"]
+    }
+  },
+  {
+    "event_id": "gen_misc_any_traitmisc1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "m_c considers, as {PRONOUN/m_c/subject} {VERB/m_c/look/looks} out over the Clan, if perhaps this isn't where {PRONOUN/m_c/subject} {VERB/m_c/belong/belongs}.",
+    "m_c": {
+      "trait": ["adventurous","daring", "insecure", "nervous"]
+    }
+  },
+  {
+    "event_id": "gen_misc_any_traitmisc2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "The world around {PRONOUN/m_c/object} feels smaller lately; m_c looks out at the horizon and yearns for something unnameable.",
+    "m_c": {
+      "trait": ["adventurous","daring"]
+    }
+  },
+  {
+    "event_id": "gen_misc_any_dark1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["skill_trait_required"],
+    "weight": 5,
+    "event_text": "m_c's dreams are filled with flashing teeth and blood-scent. {PRONOUN/m_c/subject/CAP} {VERB/m_c/wake/wakes} up screaming.",
+    "m_c": {
+      "skill": ["DARK,0"]
+    }
+  },
+  {
+    "event_id": "gen_misc_any_ghost1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["skill_trait_required"],
+    "weight": 5,
+    "event_text": "m_c thought {PRONOUN/m_c/subject} saw a familar wispy form lingering at the edge of camp, but the ghost disappeared before {PRONOUN/m_c/subject} could be sure.",
+    "m_c": {
+      "skill": ["GHOST,0"]
+    }
+  },
+  {
+    "event_id": "gen_misc_leaffall_misc1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["leaf-fall"],
+    "tags": ["clan_kits"],
+    "weight": 20,
+    "event_text": "The older cats look fondly upon the kits who are dashing in and out of leaf piles at the edge of camp.",
+    "m_c": {
+      "age": ["adolescent", "young adult", "adult", "senior adult", "senior"]
+    }
+  },
+  {
+    "event_id": "gen_misc_leafbare_misc1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["leafbare"],
+    "weight": 20,
+    "event_text": "m_c and r_c begin a small camp snowball fight while on guard duty, eventually getting the whole Clan to join in.",
+    "m_c": {
+        "age": ["young adult","adult","senior adult"]
+    },
+    "r_c": {
+        "age": ["young adult","adult","senior adult"]
+    },
+    "relationships": [
+        {
+            "mututal": true,
+            "values": ["platonic","comfort", "trust"],
+            "amount": 5
+        },
+        {
+            "mututal": true,
+            "values": ["dislike"],
+            "amount": -5
         }
+    ]
+  },
+  {
+    "event_id": "gen_misc_leafbare_misc2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["leaf-bare"],
+    "weight": 15,
+    "event_text": "m_c encourages r_c to play in the snow with {PRONOUN/m_c/object} during a patrol.",
+    "m_c": {
+        "age": ["young adult","adult","senior adult"],
+        "trait": ["playful"]
     },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c visits o_c to converse with their medicine cats about an omen StarClan sent.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ],
-            "skill": [
-                "STAR,0",
-                "CLAIRVOYANT,0",
-                "OMEN,0",
-                "DREAM,0"
-            ]
-        },
-        "other_clan": {
-            "current_rep": [],
-            "changed": 0
+    "r_c":{
+        "age": ["young adult","adult","senior adult"]
+    },
+    "relationships": [
+        {
+          "mutual": true,
+          "values": ["comfort"],
+          "amount": 5
         }
+    ]
+},
+  {
+    "event_id": "gen_misc_any_accessory1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "m_c always seems to have acc_plural stuck in {PRONOUN/m_c/poss} fur.",
+    "new_accessory": ["HERBS","PETALS","DRY HERBS", "RED FEATHERS", "BLUE FEATHERS","JAY FEATHERS"]
+  },
+  {
+    "event_id": "gen_misc_any_accessory2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "r_c finds acc_plural while out on a walk and decides to give them to m_c.",
+    "new_accessory": ["WILD","PLANT"],
+    "r_c": {
+        "age": ["adolescent", "young adult","adult","senior","senior adult"]
     },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c visits o_c to congratulate them on their new medicine cat.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ],
-            "skill": [
-                "MEDIATOR,1"
-            ]
+    "relationships": [
+        {
+            "mututal": true,
+            "values": ["platonic", "comfort", "trust"],
+            "amount": 5
         },
-        "other_clan": {
-            "current_rep": [],
-            "changed": 0
+        {
+            "mututal": true,
+            "values": ["dislike"],
+            "amount": -5
         }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "ceremony"
-        ],
-        "weight": 20,
-        "event_text": "r_c presents m_c with acc_plural as a congratulations.",
-        "new_accessory": [
-            "WILD",
-            "PLANT"
-        ],
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "dislike"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c always seems to have acc_plural stuck in {PRONOUN/m_c/poss} fur.",
-        "new_accessory": [
-            "HERBS",
-            "PETALS",
-            "DRY HERBS"
-        ],
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ]
+    ]
+  },
+  {
+    "event_id": "gen_misc_any_accessory3",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "m_c finds acc_plural while out on a walk and decides to keep them.",
+    "new_accessory": ["WILD","PLANT"]
+  },
+  {
+    "event_id": "gen_misc_any_accessory4",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["ceremony"],
+    "weight": 20,
+    "event_text": "m_c was given acc_plural as a congratulations, r_c watches from the side with a jealous glint in {PRONOUN/r_c/poss} eyes.",
+    "new_accessory": ["WILD", "PLANT"],
+    "relationships": [
+        {
+            "cats_from": ["r_c"],
+            "cats_to": ["m_c"],
+            "values": ["platonic","comfort","respect"],
+            "amount": -5
         }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c speaks to r_c about an omen {PRONOUN/m_c/subject} saw while on patrol recently.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ],
-            "relationship_status": [],
-            "skill": [
-                "OMEN,0"
-            ]
-        },
-        "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c speaks to r_c about a potential omen and what it means.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ],
-            "relationship_status": [],
-            "skill": [
-                "OMEN,0"
-            ]
-        },
-        "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "skill_trait_required"
-        ],
-        "weight": 20,
-        "event_text": "m_c walks into the dreams of {PRONOUN/m_c/poss} Clanmates while everyone sleeps.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ],
-            "skill": [
-                "DREAM,2"
-            ]
+    ]
+  }, 
+  {
+    "event_id": "gen_misc_any_accessory5",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "m_c received a present, acc_plural, from r_c and decided to keep it with {PRONOUN/m_c/object} on {PRONOUN/m_c/poss} pelt.",
+    "new_accessory": ["WILD", "PLANT"],
+    "relationships": [
+        {
+            "mututal": true,
+            "values": ["platonic", "comfort"],
+            "amount": 5
         }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "skill_trait_required"
-        ],
-        "weight": 20,
-        "event_text": "m_c correctly warns the leader of an ambush, thanks to {PRONOUN/m_c/poss} clairvoyant nature.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ],
-            "skill": [
-                "CLAIRVOYANT,2"
-            ]
+    ]
+  },
+  {
+    "event_id": "gen_misc_any_accessory6",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["ceremony"],
+    "weight": 20,
+    "event_text": "m_c decides to pick something to adorn {PRONOUN/m_c/poss} pelt as celebration.",
+    "new_accessory": ["WILD","PLANT"]
+  },
+  {
+    "event_id": "gen_misc_any_accessory7",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["ceremony"],
+    "weight": 20,
+    "event_text": "r_c gives m_c something to adorn {PRONOUN/m_c/poss} pelt as congratulations.",
+    "new_accessory": ["WILD","PLANT"],
+    "relationships": [
+        {
+            "mututal": true,
+            "values": ["platonic","comfort"],
+            "amount": 5
+        },
+        {
+            "mututal": true,
+            "values": ["dislike"],
+            "amount": -5
         }
+    ]
+  },
+  {
+    "event_id": "gen_misc_leafbare_accessory1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["leaf-bare"],
+    "weight": 20,
+    "event_text": "m_c found a mysterious acc_singular growing in the frost and decided to wear it.",
+    "new_accessory": ["FORGET ME NOTS", "BLUEBELLS", "POPPY"]
+  },
+  {
+    "event_id": "gen_misc_war_any_any1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "The war with o_c is beginning to disrupt the daily lives of c_n, forcing them to adapt to new routines and living situations in order to better defend themselves.",
+    "other_clan": {
+        "current_rep": ["hostile"],
+        "changed": -10
+    }
+  },
+  {
+    "event_id": "gen_misc_war_any_any2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "The tension between c_n and o_c is palpable, with even the smallest actions potentially leading to violence.",
+    "other_clan": {
+        "current_rep": ["hostile"],
+        "changed": -5
+    }
+  },
+  {
+    "event_id": "gen_misc_any_mate1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 5,
+    "event_text": "m_c and r_c are so cuddled up and cozy in their nest they almost miss the dawn patrol.",
+    "m_c": {
+      "relationship_status": ["mates"]
     },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c spends {PRONOUN/m_c/poss} day communing with StarClan, attempting to figure out a recent prophecy.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ],
-            "skill": [
-                "PROPHET,2"
-            ]
+    "relationships": [
+        {
+          "mutual": true,
+          "values": ["romantic", "comfort","trust"],
+          "amount": 10
         }
+    ]
+  },
+  {
+    "event_id": "gen_misc_any_mate2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["clan_kits"],
+    "weight": 10,
+    "event_text": "m_c listens bashfully as r_c tells the story of how {PRONOUN/r_c/subject} fell in love with {PRONOUN/r_c/poss} mate to a group of starry-eyed kits.",
+    "m_c": {
+      "relationship_status": ["mates"]
     },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c has been worried that c_n will lose the knowledge r_c has gained through {PRONOUN/r_c/poss} long life, but by sitting with r_c and discussing {PRONOUN/r_c/poss} experiences, m_c will ensure the lessons learned in the past are never forgotten.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ],
-            "relationship_status": [],
-            "skill": [
-                "LORE,0"
-            ]
-        },
-        "r_c": {
-            "age": [
-                "senior",
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "skill_trait_required"
-        ],
-        "weight": 20,
-        "event_text": "m_c tosses in {PRONOUN/m_c/poss} sleep as {PRONOUN/m_c/poss} dreamself pads through the thoughts of {PRONOUN/m_c/poss} Clanmates, picking up snippets of dream_list. {PRONOUN/m_c/subject/CAP} slowly {VERB/m_c/blink/blinks} awake, wondering whose dreams {PRONOUN/m_c/subject} walked in.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ],
-            "skill": [
-                "DREAM,2"
-            ]
+    "relationships": [
+        {
+          "mutual": true,
+          "values": ["romantic", "platonic","trust"],
+          "amount": 10
         }
+    ]
+  },
+  {
+    "event_id": "gen_misc_any_mate3",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 15,
+    "event_text": "m_c watches r_c give an elder the best piece of prey on the pile. {PRONOUN/m_c/subject/CAP} {VERB/m_c/feel/feels} lucky to have such a kind cat as {PRONOUN/m_c/poss} mate.",
+    "m_c": {
+      "relationship_status": ["mates"]
     },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c disappears for a few days, then returns to camp with a acc_singular around {PRONOUN/m_c/poss} neck.",
-        "new_accessory": [
-            "COLLAR"
-        ],
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ]
+    "relationships": [
+        {
+          "mutual": true,
+          "values": ["trust"],
+          "amount": 10
         }
+    ]
+  },
+  {
+    "event_id": "gen_misc_any_mate4",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["clan_kits"],
+    "weight": 15,
+    "event_text": "m_c and r_c watch the Clan's kits play and daydream about having their own one day.",
+    "m_c": {
+      "relationship_status": ["mates"]
     },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen loudly bickering with the medicine cat of o_c.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ]
-        },
-        "other_clan": {
-            "current_rep": [],
-            "changed": 0
+    "relationships": [
+        {
+          "mutual": true,
+          "values": ["trust"],
+          "amount": 10
         }
+    ]
+  },
+  {
+    "event_id": "gen_misc_any_mate5",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 15,
+    "event_text": "m_c and r_c take a late night patrol out of camp to watch the sun rise.",
+    "m_c": {
+      "relationship_status": ["can_romance"]
     },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen talking with a traveling loner healer on the border.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ]
+    "relationships": [
+        {
+          "mutual": true,
+          "values": ["romantic", "comfort","trust"],
+          "amount": 10
         }
+    ]
+  },
+  {
+    "event_id": "gen_misc_any_mate6",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 15,
+    "event_text": "m_c and r_c take an early evening patrol out of camp to watch the moon rise.",
+    "m_c": {
+      "relationship_status": ["can_romance"]
     },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen touching noses with someone from o_c. Scandalous!",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ]
-        },
-        "other_clan": {
-            "current_rep": [],
-            "changed": 0
+    "relationships": [
+        {
+          "mutual": true,
+          "values": ["romantic", "comfort","trust"],
+          "amount": 10
         }
+    ]
+  },
+  {
+    "event_id": "gen_misc_newleaf_mate1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["newleaf"],
+    "weight": 5,
+    "event_text": "m_c sits still as r_c helps remove some leftover Leaf-bare fluff from the back of {PRONOUN/m_c/poss} neck.",
+    "m_c": {
+      "relationship_status": ["mates"]
     },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "war"
-        ],
-        "weight": 20,
-        "event_text": "m_c's knowledge of herbs and healing is being put to the test, with injuries becoming more severe in the midst of war.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ]
+    "relationships": [
+        {
+          "mutual": true,
+          "values": ["platonic","trust"],
+          "amount": 10
         }
+    ]
+  },
+  {
+    "event_id": "gen_misc_greenleaf_mate2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["greenleaf"],
+    "weight": 10,
+    "event_text": "It's tough working in such extreme heat. m_c and r_c spend their evening relaxing together and cooling down in the shade.",
+    "m_c": {
+      "relationship_status": ["mates"]
     },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "war"
-        ],
-        "weight": 20,
-        "event_text": "m_c watches every little thing around {PRONOUN/m_c/object} for any omen that indicates what the Clan should do in the war. The losses weigh heavy on the hearts of every cat.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ],
-            "skill": [
-                "OMEN,0"
-            ]
+    "relationships": [
+        {
+          "mutual": true,
+          "values": ["romantic", "comfort","trust"],
+          "amount": 10
         }
+    ]
+  },
+  {
+    "event_id": "gen_misc_any_mateaccessory1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 15,
+    "event_text": "m_c gives r_c a acc_singular to make up for a bad fight between them.",
+    "new_accessory": ["WILD", "PLANT"],
+    "m_c": {
+      "relationship_status": ["mates"]
     },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "war"
-        ],
-        "weight": 20,
-        "event_text": "m_c preps battle herbs into small bundles to rush to the battlefield in case of severe injuries.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ]
+    "relationships": [
+        {
+          "mutual": true,
+          "values": ["romantic", "comfort","trust"],
+          "amount": 10
         }
+    ]
+  },
+  {
+    "event_id": "gen_misc_any_mateaccessory2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 5,
+    "event_text": "m_c gifts {PRONOUN/m_c/poss} beloved r_c with a acc_singular to wear in {PRONOUN/m_c/poss} pelt.",
+    "new_accessory": ["WILD", "PLANT"],
+    "m_c": {
+      "relationship_status": ["mates"]
     },
-    {
-        "event_id": "gen_misc_",
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [
-            "war"
-        ],
-        "weight": 20,
-        "event_text": "m_c hopes to find the herbs that c_n needs in the war, and goes to look for them even in this leafbare's harsh weather.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ]
+    "relationships": [
+        {
+          "mutual": true,
+          "values": ["romantic", "comfort","trust"],
+          "amount": 15
         }
+    ]
+  },
+  {
+    "event_id": "gen_misc_greenleaf_mateaccessory1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["greenleaf"],
+    "weight": 15,
+    "event_text": "m_c and r_c spend the evening chasing cicadas around camp. m_c keeps a trophy of {PRONOUN/m_c/poss} catch on {PRONOUN/m_c/poss} pelt.",
+    "new_accessory": ["CICADA WINGS"],
+    "m_c": {
+      "relationship_status": ["mates"]
     },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "war"
-        ],
-        "weight": 20,
-        "event_text": "c_n is in a badly need of herbs, and m_c knows it, but can't bring {PRONOUN/m_c/self} to leave {PRONOUN/m_c/poss} patients' side.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ]
+    "relationships": [
+        {
+          "mutual": true,
+          "values": ["romantic", "comfort","trust"],
+          "amount": 10
         }
+    ]
+  },
+  {
+    "event_id": "gen_misc_leaffall_mateaccessory1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["greenleaf"],
+    "weight": 10,
+    "event_text": "r_c gives m_c the prettiest fallen leaf {PRONOUN/r_c/subject} can find. m_c wears it with pride.",
+    "new_accessory": ["MAPLE LEAF"],
+    "m_c": {
+      "relationship_status": ["mates"]
     },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "Any"
-        ],
-        "season": [],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c is getting increasingly annoyed with r_c because {PRONOUN/r_c/subject} {VERB/r_c/keep/keeps} bothering {PRONOUN/m_c/object} about the most trivial of wounds and aches.",
-        "m_c": {
-            "age": [
-                "adolescent",
-                "senior"
-            ],
-            "status": [
-                "medicine cat apprentice",
-                "medicine cat"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c is scolded after sneaking out of camp.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ]
+    "relationships": [
+        {
+          "mutual": true,
+          "values": ["romantic", "comfort","trust"],
+          "amount": 10
         }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c falls into a river, but is saved by r_c.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was playing with acc_plural earlier, and decides to wear some of them.",
-        "new_accessory": [
-            "RED FEATHERS",
-            "BLUE FEATHERS",
-            "JAY FEATHERS"
-        ],
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "No matter how hard r_c tries, there's always something stuck in m_c's fur.",
-        "new_accessory": [
-            "HERBS",
-            "PETALS",
-            "DRY HERBS"
-        ],
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "relationship_status": [
-                "child/parent"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c is just too cute - r_c gives {PRONOUN/m_c/object} a pretty acc_singular as a gift.",
-        "new_accessory": [
-            "WILD",
-            "PLANT"
-        ],
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "relationship_status": [],
-            "trait": [
-                "sweet",
-                "polite"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "r_c gives m_c a pretty acc_singular {PRONOUN/r_c/subject} found while playing.",
-        "new_accessory": [
-            "WILD",
-            "PLANT"
-        ],
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "dislike"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "jealousy"
-        ],
-        "weight": 20,
-        "event_text": "m_c starts bringing a pretty acc_singular everywhere {PRONOUN/m_c/subject} {VERB/m_c/go/goes}, and r_c loudly complains that {PRONOUN/r_c/subject} {VERB/r_c/want/wants} one, too.",
-        "new_accessory": [
-            "WILD",
-            "PLANT"
-        ],
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [],
-            "trait": [
-                "bullying",
-                "impulsive",
-                "attention-seeker"
-            ]
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "dislike",
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c finds some acc_singular to wear in {PRONOUN/m_c/poss} fur to impress r_c!",
-        "new_accessory": [
-            "WILD",
-            "PLANT"
-        ],
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "relationship_status": [
-                "child/parent"
-            ],
-            "trait": [
-                "attention-seeker",
-                "charming"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf",
-            "newleaf"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c and r_c sneak out of camp to chase butterflies.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "leaf-fall"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c and r_c play with the leaves around the camp.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c and r_c chase fireflies around the camp, while the older warriors try to sleep.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c and r_c make little snow lumps at the entrance to the camp.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c and r_c flick snow at the older warriors, giggling as they hide behind the nursery.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
+    ]
+  },
+  {
+    "event_id": "gen_misc_any_retireany1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "m_c thinks about retiring.",
+    "m_c": {
+        "status": ["any"],
+        "age": ["senior adult", "senior"]
+    }
+  },
+  {
+    "event_id": "gen_misc_multi_kit1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["greenleaf", "newleaf"],
+    "weight": 15,
+    "event_text": "m_c picks some flowers around the camp to bring back to the medicine den.",
+    "m_c": {
+      "age": ["kitten"],
+      "status": ["kitten"]
+    }
+  },
+  {
+    "event_id": "gen_misc_greenleaf_kit1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["greenleaf"],
+    "weight": 15,
+    "event_text": "m_c chases fireflies around the camp, while the older warriors sleep.",
+    "m_c": {
+      "age": ["kitten"],
+      "status": ["kitten"]
+    }
+  },
+  {
+        "event_id": "gen_misc_any_kitkit1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 10,
         "event_text": "m_c and r_c try to sneak out of camp, but are caught and returned to the nursery.",
         "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "relationship_status": []
+            "age": ["kitten"],
+            "status": ["kitten"]
         },
         "r_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": []
+          "status": ["kitten"]
         },
         "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["r_c"],
+            "mutual": true,
+            "values": ["platonic"],
+            "amount": 10
+          }
         ]
     },
     {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf",
-            "newleaf"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c picks some flowers around the camp to bring back to the medicine den.",
+        "event_id": "gen_misc_multi_kitkit1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["newleaf", "greenleaf"],
+        "weight": 15,
+        "event_text": "m_c and r_c sneak out of camp to chase butterflies.",
         "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ]
-        }
+            "status": ["kitten"]
+        },
+        "r_c": {
+          "status": ["kitten"]
+        },
+        "relationships": [
+          {
+            "mutual": true,
+            "values": ["platonic", "trust", "comfort"],
+            "amount": 10
+          }
+        ]
     },
     {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c chases fireflies around the camp, while the older warriors sleep.",
+        "event_id": "gen_misc_greenleaf_kitkit1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["greenleaf"],
+        "weight": 15,
+        "event_text": "m_c and r_c chase fireflies around the camp, while the older warriors try to sleep.",
         "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ]
-        }
+            "age": ["kitten"],
+            "status": ["kitten"]
+        },
+        "r_c": {
+          "status": ["kitten"]
+        },
+        "relationships": [
+          {
+            "mutual": true,
+            "values": ["platonic", "trust", "comfort"],
+            "amount": 10
+          }
+        ]
     },
     {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "leaf-fall"
-        ],
-        "tags": [],
-        "weight": 20,
+        "event_id": "gen_misc_leaffall_kitkit1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["leaf-fall"],
+        "weight": 10,
         "event_text": "m_c and r_c lead a small leaf-gathering hunt, which the adult cats watch with amused purrs.",
         "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "relationship_status": []
+            "age": ["kitten"],
+            "status": ["kitten"]
         },
         "r_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": []
+          "status": ["kitten"]
         },
         "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust"
-                ],
-                "amount": 5
-            }
+          {
+            "mutual": true,
+            "values": ["platonic", "comfort", "trust"],
+            "amount": 10
+          }
         ]
     },
     {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "war",
-            "clan_kits"
-        ],
-        "weight": 20,
+        "event_id": "gen_misc_leaffall_kitkit2",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["leaf-fall"],
+        "weight": 15,
+        "event_text": "m_c and r_c play with the leaves around the camp.",
+        "m_c": {
+            "age": ["kitten"],
+            "status": ["kitten"]
+        },
+        "r_c": {
+          "status": ["kitten"]
+        },
+        "relationships": [
+          {
+            "mutual": true,
+            "values": ["platonic", "trust", "comfort"],
+            "amount": 10
+          }
+        ]
+    },
+    {
+        "event_id": "gen_misc_leafbare_kitkit1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["leafbare"],
+        "weight": 10,
+        "event_text": "m_c and r_c make little snow lumps at the entrance to the camp.",
+        "m_c": {
+            "age": ["kitten"],
+            "status": ["kitten"]
+        },
+        "r_c": {
+          "status": ["kitten"]
+        },
+        "relationships": [
+          {
+            "mutual": true,
+            "values": ["platonic", "trust", "comfort"],
+            "amount": 10
+          }
+        ]
+      },
+    {
+        "event_id": "gen_misc_leafbare_kitkit2",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["leafbare"],
+        "weight": 10,
+        "event_text": "m_c and r_c flick snow at the older warriors, giggling as they hide behind the nursery.",
+        "m_c": {
+            "age": ["kitten"],
+            "status": ["kitten"]
+        },
+        "r_c": {
+          "status": ["kitten"]
+        },
+        "relationships": [
+          {
+            "mutual": true,
+            "values": ["platonic", "trust", "comfort"],
+            "amount": 10
+          }
+        ]
+    },
+    {
+        "event_id": "gen_misc_war_any_kitparent1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "tags": ["war"],
+        "weight": 10,
         "event_text": "m_c is being comforted by r_c after having nightmares about the big, bad o_c cats.",
         "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "relationship_status": [
-                "child/parent"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
+            "age": ["kitten"],
+            "status": ["kitten"],
+            "relationship_status": ["child/parent"]
         },
         "relationships": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "comfort"
-                ],
-                "amount": 5
-            }
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["r_c"],
+            "mutual": false,
+            "values": ["comfort"],
+            "amount": 20
+          }
         ]
     },
     {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf",
-            "newleaf"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c caught an insect while sneaking outside of the camp and proudly wears its wings as a trophy of {PRONOUN/m_c/poss} journey.",
-        "new_accessory": [
-            "MOTH WINGS",
-            "CICADA WINGS"
-        ],
+        "event_id": "gen_misc_any_accessorykit1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 15,
+        "event_text": "m_c was playing with acc_plural earlier, and decides to wear some of them.",
+        "new_accessory": ["RED FEATHERS", "BLUE FEATHERS", "JAY FEATHERS"],
         "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ]
+          "age": ["kitten"],
+          "status": ["kitten"]
         }
     },
     {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "leaf-fall"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "As the wind brings many fallen leaves in the camp, m_c picks a acc_singular to decorate {PRONOUN/m_c/poss} pelt.",
-        "new_accessory": [
-            "OAK LEAVES",
-            "MAPLE LEAF"
-        ],
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "newleaf"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "As the wind blows many petals in the camp, m_c picks a few to decorate {PRONOUN/m_c/self}.",
-        "new_accessory": [
-            "PETALS"
-        ],
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
+        "event_id": "gen_misc_any_accessorykit2",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 15,
         "event_text": "m_c sneaked out of camp, and brought back with them some acc_singular from when {PRONOUN/m_c/poss} fur got snagged in a bush.",
-        "new_accessory": [
-            "HOLLY",
-            "JUNIPER"
-        ],
+        "new_accessory": ["HOLLY", "JUNIPER"],
         "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ]
+            "age": ["kitten"],
+            "status": ["kitten"]
         }
     },
     {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c thinks about retiring.",
+        "event_id": "gen_misc_multi_accessorykit1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["newleaf", "greenleaf"],
+        "weight": 15,
+        "event_text": "m_c caught an insect while sneaking outside of the camp and proudly wears its wings as a trophy of {PRONOUN/m_c/poss} journey.",
+        "new_accessory": ["MOTH WINGS", "CICADA WINGS"],
         "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "deputy"
-            ]
+          "age": ["kitten"],
+          "status": ["kitten"]
         }
     },
     {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c travels to o_c to bring them an important message.",
+      "event_id": "gen_misc_newleaf_accessorykit1",
+      "biome": ["any"],
+      "camp": ["any"],
+      "season": ["newleaf"],
+      "weight": 15,
+      "event_text": "As the wind blows many petals in the camp, m_c picks a few to decorate {PRONOUN/m_c/self}.",
+      "new_accessory": ["PETALS"],
+      "m_c": {
+        "age": ["kitten"],
+        "status": ["kitten"]
+      }
+    },
+    {
+        "event_id": "gen_misc_leaffall_accessorykit1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["leaf-fall"],
+        "weight": 15,
+        "event_text": "As the wind brings many fallen leaves in the camp, m_c picks a acc_singular to decorate {PRONOUN/m_c/poss} pelt.",
+        "new_accessory": ["OAK LEAVES", "MAPLE LEAF"],
         "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "deputy"
-            ]
-        },
-        "other_clan": {
-            "current_rep": [],
-            "changed": 0
+            "age": ["kitten"],
+            "status": ["kitten"]
         }
     },
     {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c travels to the other Clans to bring them an important message.",
+        "event_id": "gen_misc_any_traitaccessorykit1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 15,
+        "event_text": "m_c is just too cute - r_c gives {PRONOUN/m_c/object} a pretty acc_singular as a gift.",
+        "new_accessory": ["WILD", "PLANT"],
         "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "deputy"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "war"
-        ],
-        "weight": 20,
-        "event_text": "As the deputy, m_c is doing {PRONOUN/m_c/poss} best to prepare for leadership in the case that the worst happens.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "deputy"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "war"
-        ],
-        "weight": 20,
-        "event_text": "m_c is struggling to accept the fact that {PRONOUN/m_c/subject} may have to step up as leader if r_c loses {PRONOUN/r_c/poss} last life. How could {PRONOUN/m_c/subject} {VERB/m_c/go/goes} on without {PRONOUN/m_c/poss} beloved leader? How difficult will it to be to lead in {PRONOUN/r_c/poss} stead?",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "deputy"
-            ],
-            "relationship_status": [],
-            "trait": [
-                "insecure",
-                "lonesome",
-                "nervous"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
+          "age": ["kitten"],
+          "status": ["kitten"],
+          "trait": ["sweet", "polite"]
         },
         "relationships": [
-            {
-                "cats_from": [
-                    "m_c"
-                ],
-                "cats_to": [
-                    "r_c"
-                ],
-                "values": [
-                    "platonic",
-                    "trust",
-                    "respect"
-                ],
-                "amount": 5
-            }
+          {
+            "mutual": true,
+            "values": ["platonic", "comfort", "trust", "respect"],
+            "amount": 10
+          }
         ]
     },
     {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "war"
-        ],
-        "weight": 20,
-        "event_text": "m_c is struggling to accept the fact that {PRONOUN/m_c/subject} may have to step up as leader if r_c loses {PRONOUN/r_c/poss} last life.",
+        "event_id": "gen_misc_any_accessorykitkit1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 15,
+        "event_text": "r_c gives m_c a pretty acc_singular {PRONOUN/r_c/subject} found while playing.",
+        "new_accessory": ["WILD", "PLANT"],
         "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "deputy"
-            ],
-            "relationship_status": [],
-            "trait": [
-                "insecure",
-                "lonesome",
-                "nervous"
-            ]
+            "age": ["kitten"],
+            "status": ["kitten"]
         },
-        "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": []
-        },
+          "r_c": {
+            "status": ["kitten"]
+          },
         "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
+          {
+            "mutual": true,
+            "values": ["platonic", "comfort", "trust"],
+            "amount": 10
+          },
+          {
+            "mutual": true,
+            "values": ["dislike"],
+            "amount": -10
+          }
         ]
     },
     {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "war"
-        ],
-        "weight": 20,
-        "event_text": "m_c is heavily relying on the tactical advice and experience of the elders, namely r_c.",
+        "event_id": "gen_misc_any_accessorykitkit2",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 10,
+        "event_text": "m_c starts bringing a pretty acc_singular everywhere {PRONOUN/m_c/subject} {VERB/m_c/go/goes}, and r_c loudly complains that {PRONOUN/r_c/subject} {VERB/r_c/want/wants} one, too.",
+        "new_accessory": ["WILD", "PLANT"],
         "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "deputy"
-            ],
-            "relationship_status": [],
-            "trait": [
-                "insecure",
-                "lonesome",
-                "nervous"
-            ]
+            "age": ["kitten"],
+            "status": ["kitten"]
         },
         "r_c": {
-            "age": [
-                "senior",
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [],
-            "skill": [
-                "INSIGHTFUL,1",
-                "TEACHER,3",
-                "CLEVER,3",
-                "CAMP,3"
-            ]
+          "status": ["kitten"],
+          "trait": ["bullying", "impulsive", "attention-seeker"]
         },
         "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
+          {
+            "mutual": true,
+            "values": ["dislike", "jealousy"],
+            "amount": 10
+          },
+          {
+            "mutual": true,
+            "values": [ "platonic", "comfort"],
+            "amount": -5
+          }
         ]
     },
     {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
+        "event_id": "gen_misc_any_accessorykitparent1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 10,
+        "event_text": "No matter how hard r_c tries, there's always something stuck in m_c's fur.",
+        "new_accessory": ["HERBS", "PETALS", "DRY HERBS"],
+        "m_c": {
+          "age": ["kitten"],
+          "status": ["kitten"],
+          "relationship_status": ["child/parent"]
+        }
+    },
+    {
+        "event_id": "gen_misc_any_accessorykitparent2",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 15,
+        "event_text": "m_c finds some acc_singular to wear in {PRONOUN/m_c/poss} fur to impress r_c!",
+        "new_accessory": ["WILD", "PLANT"],
+        "m_c": {
+            "age": ["kitten"],
+            "status": ["kitten"],
+            "relationship_status": ["child/parent"],
+            "trait": ["attention-seeker", "charming"]
+        }
+    },
+    {
+        "event_id": "gen_misc_any_kitapprentice1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 15,
         "event_text": "m_c is scolded after sneaking out of camp.",
         "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
+            "age": ["kitten", "adolescent"],
+            "status": ["kitten", "apprentice"]
         }
     },
     {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
+        "event_id": "gen_misc_any_adultsavingkitapprentice1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 15,
         "event_text": "m_c falls into a river, but is saved by r_c.",
         "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": []
+            "age": ["kitten", "adolescent"],
+            "status": ["kitten", "apprentice"]
         },
         "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": []
+          "age": ["young adult", "adult", "senior adult", "senior"]
         },
         "relationships": [
-            {
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
-                "amount": 5
-            }
+          {
+            "mutual": true,
+            "values": ["platonic", "comfort", "respect", "trust"],
+            "amount": 15
+          }
         ]
     },
     {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c accidentally trespasses onto o_c's territory.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        },
-        "other_clan": {
-            "current_rep": [],
-            "changed": -5
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c sneaks out of camp with r_c.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [],
-        "tags": [
-            "neg_jealousy"
-        ],
-        "weight": 20,
-        "event_text": "m_c and r_c were chatting about their day and the chores they finished when r_c mentioned {PRONOUN/r_c/subject} liked the smell of wild fruit. m_c decides to wear acc_plural on {PRONOUN/m_c/poss} pelt, hoping that r_c notices {PRONOUN/m_c/object}.",
-        "new_accessory": [
-            "BLUE BERRIES",
-            "HOLLY"
-        ],
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "romantic",
-                    "comfort",
-                    "trust",
-                    "respect"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "leaf-fall"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c is nearly blindsided by r_c as {PRONOUN/r_c/subject} {VERB/r_c/walk/walks} into camp after a long training day, listening to the kit squeak about a type of feather. r_c leads m_c to the nursery, where {PRONOUN/r_c/subject} carefully put acc_plural in m_c's fur.",
-        "new_accessory": [
-            "BLUE FEATHERS"
-        ],
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [
-                    "platonic",
-                    "comfort"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "jealousy"
-        ],
-        "weight": 20,
-        "event_text": "m_c, for the umpteenth time, hears r_c complaining about the dry rye stalks underneath {PRONOUN/r_c/poss} paws when {PRONOUN/r_c/subject} {VERB/r_c/finish/finishes} cleaning the elders' den and got an idea. The next day, m_c adorns {PRONOUN/m_c/poss} pelt with acc_plural.",
-        "new_accessory": [
-            "RYE STALK"
-        ],
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [
-                    "dislike"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c and r_c sneak out of camp to see the sun rise.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "dislike"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c and r_c sneak out of camp to see the moon rise.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "dislike"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c and r_c try to sneak out of camp, but are caught by their mentors.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "leaf-fall"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c and r_c play in the fallen leaves outside of camp.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "dislike"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c and r_c play in the snow outside of camp.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "dislike"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c gets dared to hunt outside in the snow alone, and returns with acc_singular in {PRONOUN/m_c/poss} pelt.",
-        "new_accessory": [
-            "WILD",
-            "PLANT"
-        ],
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c disappears for a few days, then returns to camp with a acc_singular around {PRONOUN/m_c/poss} neck.",
-        "new_accessory": [
-            "COLLAR"
-        ],
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf",
-            "newleaf",
-            "leaf-fall"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c and r_c were practicing climbing when they found a nest of strange eggs.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "dislike"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf",
-            "newleaf",
-            "leaf-fall"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c and r_c sneak out of camp to go bird watching.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "dislike"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c encourages r_c to play in the snow with {PRONOUN/m_c/object} during a patrol.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": [],
-            "trait": "playful"
-        },
-        "r_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c gives r_c a acc_singular to make up for a bad fight between them.",
-        "new_accessory": [
-            "WILD",
-            "PLANT"
-        ],
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [
-                    "romantic",
-                    "comfort",
-                    "trust"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen racing along the border with {PRONOUN/m_c/poss} rival from o_c.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        },
-        "other_clan": {
-            "current_rep": [],
-            "changed": 0
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen playing with a kittypet over the border.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen taking food from a Twoleg!",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen speaking with someone from o_c.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        },
-        "other_clan": {
-            "current_rep": [],
-            "changed": 0
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen speaking with a loner.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen speaking with a rogue.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen speaking with a kittypet.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen chasing a rogue off of the territory.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen chasing a loner off of the territory.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen chasing a kittypet off of the territory.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was caught sharing prey with a rogue, who was chased off by a patrol.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was caught sharing prey with a kittypet, who was chased off by a patrol.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was loitering around o_c's border, looking for a specific cat.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        },
-        "other_clan": {
-            "current_rep": [],
-            "changed": 0
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen arguing, and borderline-fighting with, a cat from o_c.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        },
-        "other_clan": {
-            "current_rep": [],
-            "changed": -5
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen arguing, and borderline-fighting with, a rogue.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        },
-        "other_clan": {
-            "current_rep": [],
-            "changed": -5
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen arguing, and borderline-fighting with, a kittypet.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        },
-        "other_clan": {
-            "current_rep": [],
-            "changed": -5
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen talking calmly to a loner, before both cats went their separate ways.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen speaking calmly to a cat from o_c.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        },
-        "other_clan": {
-            "current_rep": [],
-            "changed": 5
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen talking calmly to a loner, before both cats went their separate ways.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen in a very serious conversation with a kittypet, who ran away when another patrol approached.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c is struggling to cope with the violence and chaos of war surrounding {PRONOUN/m_c/object}, finding it difficult to wake up in the morning due to the stress and strain of constant battle training.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ],
-            "trait": [
-                "nervous",
-                "lonesome",
-                "playful",
-                "careful",
-                "compassionate",
-                "loving",
-                "insecure"
-            ]
-        },
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": 0
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "war"
-        ],
-        "weight": 20,
-        "event_text": "m_c feels like {PRONOUN/m_c/subject} might be growing up too fast in the midst of war.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c goes to o_c in an attempt to ease the tension of war between the Clans: it goes well, and o_c begins to draw back from c_n's territory!",
-        "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "mediator",
-                "mediator apprentice"
-            ]
-        },
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": 5
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c goes to o_c in an attempt to ease the tension of war between the Clans: it doesn't go well, and o_c further advances in c_n's territory.",
-        "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "mediator",
-                "mediator apprentice"
-            ]
-        },
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": -5
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c pulls r_c to the side, quietly asking {PRONOUN/r_c/object} about {PRONOUN/r_c/poss} crush on a fellow Clanmate.",
-        "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "mediator",
-                "mediator apprentice"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "comfort",
-                    "trust",
-                    "dislike"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c spots r_c looking a little bit lonely, and invites {PRONOUN/r_c/object} to watch as {PRONOUN/m_c/subject} {VERB/m_c/perform/performs} {PRONOUN/m_c/poss} duties.",
-        "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "mediator",
-                "mediator apprentice"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "dislike"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "war"
-        ],
-        "weight": 20,
-        "event_text": "m_c is conversing with r_c about ways to potentially end this war without bloodshed.",
-        "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "mediator",
-                "mediator apprentice"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [],
-            "trait": [
-                "calm",
-                "careful",
-                "insecure",
-                "lonesome",
-                "loyal",
-                "nervous",
-                "compassionate",
-                "faithful",
-                "loving",
-                "responsible",
-                "thoughtful",
-                "wise",
-                "inquisitive",
-                "childish",
-                "playful"
-            ]
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "war"
-        ],
-        "weight": 20,
-        "event_text": "m_c is conversing with r_c about ways to potentially end this war- but not without bloodshed.",
-        "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "mediator",
-                "mediator apprentice"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [],
-            "trait": [
-                "bold",
-                "charismatic",
-                "confident",
-                "daring",
-                "righteous",
-                "ambitious",
-                "bloodthirsty",
-                "cold",
-                "fierce",
-                "shameless",
-                "strict",
-                "troublesome",
-                "vengeful",
-                "sneaky",
-                "strange"
-            ]
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "war"
-        ],
-        "weight": 20,
-        "event_text": "m_c is giving r_c bad war advice on purpose.",
-        "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "mediator",
-                "mediator apprentice"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [],
-            "trait": [
-                "bold",
-                "charismatic",
-                "confident",
-                "daring",
-                "righteous",
-                "ambitious",
-                "bloodthirsty",
-                "cold",
-                "fierce",
-                "shameless",
-                "strict",
-                "troublesome",
-                "vengeful",
-                "sneaky",
-                "strange"
-            ]
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "war"
-        ],
-        "weight": 20,
-        "event_text": "m_c is checking in on every cat in the camp to make sure everyone is staying healthy in the midst of war.",
-        "m_c": {
-            "age": [
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "mediator",
-                "mediator apprentice"
-            ]
-        },
-        "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [],
-            "trait": [
-                "calm",
-                "careful",
-                "insecure",
-                "lonesome",
-                "loyal",
-                "nervous",
-                "compassionate",
-                "faithful",
-                "loving",
-                "responsible",
-                "thoughtful",
-                "wise",
-                "inquisitive",
-                "childish",
-                "playful"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c thinks about retiring.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "leader"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c feels as though the responsibility of leadership is crushing {PRONOUN/m_c/object}.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "leader"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c calls a Clan meeting to give an important announcement.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "leader"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "low_lives"
-        ],
-        "weight": 20,
-        "event_text": "m_c confesses {PRONOUN/m_c/subject} {VERB/m_c/don't/doesn't} have many lives left.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "leader"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c assesses r_c's progress.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "leader"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "war"
-        ],
-        "weight": 20,
-        "event_text": "m_c feels burdened with the weight of {PRONOUN/m_c/poss} decisions, knowing that every choice they make could mean the difference between victory and defeat.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "leader"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "war"
-        ],
-        "weight": 20,
-        "event_text": "m_c's relationships with {PRONOUN/m_c/poss} Clanmates are strained, with some questioning {PRONOUN/m_c/poss} decisions and others relying on {PRONOUN/m_c/object} more heavily than ever.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "leader"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "war"
-        ],
-        "weight": 20,
-        "event_text": "m_c is forced to be a symbol of strength and unity for {PRONOUN/m_c/poss} Clan, even in the face of {PRONOUN/m_c/poss} own doubts and fears.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "leader"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c is caught breaking the Warrior Code.",
-        "m_c": {
-            "age": [],
-            "status": []
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c went missing for a few days.",
-        "m_c": {
-            "age": [],
-            "status": []
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c believes {PRONOUN/m_c/subject} {VERB/m_c/are/is} part of a new prophecy.",
-        "m_c": {
-            "age": [],
-            "status": []
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c believes {PRONOUN/m_c/subject}'{VERB/m_c/re/s} meant for something greater.",
-        "m_c": {
-            "age": [],
-            "status": []
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c tries to convince r_c to run away with {PRONOUN/m_c/object}.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c is caught outside of the Clan's territory.",
-        "m_c": {
-            "age": [],
-            "status": []
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "ceremony"
-        ],
-        "weight": 20,
-        "event_text": "r_c gives m_c something to adorn {PRONOUN/m_c/poss} pelt as congratulations.",
-        "new_accessory": [
-            "WILD",
-            "PLANT"
-        ],
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "dislike"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "ceremony"
-        ],
-        "weight": 20,
-        "event_text": "m_c decides to pick something to adorn {PRONOUN/m_c/poss} pelt as celebration.",
-        "new_accessory": [
-            "WILD",
-            "PLANT"
-        ],
-        "m_c": {
-            "age": [],
-            "status": []
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c found a mysterious acc_singular growing in the frost and decided to wear it.",
-        "new_accessory": [
-            "FORGET ME NOTS",
-            "BLUEBELLS",
-            "POPPY"
-        ],
-        "m_c": {
-            "age": [],
-            "status": []
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c received a present, acc_plural, from r_c and decided to keep it with {PRONOUN/m_c/object} on {PRONOUN/m_c/poss} pelt.",
-        "new_accessory": [
-            "WILD",
-            "PLANT"
-        ],
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "dislike"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "ceremony",
-            "jealousy"
-        ],
-        "weight": 20,
-        "event_text": "m_c was given acc_plural as a congratulations, r_c watches from the side with a jealous glint in {PRONOUN/r_c/poss} eyes.",
-        "new_accessory": [
-            "WILD",
-            "PLANT"
-        ],
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "romantic",
-                    "platonic",
-                    "comfort",
-                    "respect"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c always seems to have acc_plural stuck in {PRONOUN/m_c/poss} fur.",
-        "new_accessory": [
-            "HERBS",
-            "PETALS",
-            "DRY HERBS",
-            "RED FEATHERS",
-            "BLUE FEATHERS",
-            "JAY FEATHERS"
-        ],
-        "m_c": {
-            "age": [],
-            "status": []
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c finds acc_plural while out on a walk and decides to keep them.",
-        "new_accessory": [
-            "WILD",
-            "PLANT"
-        ],
-        "m_c": {
-            "age": [],
-            "status": []
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "r_c finds acc_plural while out on a walk and decides to give them to m_c.",
-        "new_accessory": [
-            "WILD",
-            "PLANT"
-        ],
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "dislike"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c tossed a snake out of the camp before it could bite someone.",
-        "m_c": {
-            "age": [],
-            "status": []
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c misstepped and slipped from a rock, but landed on {PRONOUN/m_c/poss} feet nimbly, {PRONOUN/m_c/poss} Clanmates commenting on the show of dexterity.",
-        "m_c": {
-            "age": [],
-            "status": []
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c wasn't looking where {PRONOUN/m_c/subject} {VERB/m_c/were/was} going and tripped over a small trunk, but came out of it with only {PRONOUN/m_c/poss} pride bruised.",
-        "m_c": {
-            "age": [],
-            "status": []
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was trying to fluff up {PRONOUN/m_c/poss} nest when {PRONOUN/m_c/subject} saw a thorn inside of {PRONOUN/m_c/poss} bedding. Another prank, but it could not fool {PRONOUN/m_c/object}!",
-        "m_c": {
-            "age": [],
-            "status": []
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "clan_kits"
-        ],
-        "weight": 20,
-        "event_text": "m_c gathered up the kits to tell them stories of story_list.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "skill": [
-                "LORE,2",
-                "KIT,1",
-                "STORY,1"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c spends the evening regaling the Clan with stories of story_list.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "skill": [
-                "LORE,2",
-                "KIT,1",
-                "STORY,1"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c and r_c begin a small camp snowball fight while on guard duty, eventually getting the whole Clan to join in.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "platonic",
-                    "comfort",
-                    "trust",
-                    "dislike"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "The tension between c_n and o_c is palpable, with even the smallest actions potentially leading to violence.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": 0
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "The war with o_c is beginning to disrupt the daily lives of c_n, forcing them to adapt to new routines and living situations in order to better defend themselves.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": 0
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "clan_kits"
-        ],
-        "weight": 20,
-        "event_text": "m_c and r_c watch the Clan's kits play and daydream about having their own one day.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [
-                "mates"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "romantic",
-                    "platonic"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c watches r_c give an elder the best piece of prey on the pile. {PRONOUN/m_c/subject/CAP} {VERB/m_c/feel/feels} lucky to have such a kind cat as {PRONOUN/m_c/poss} mate.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [
-                "mates"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c watches r_c give an elder the best piece of prey on the pile. {PRONOUN/m_c/subject} {VERB/m_c/feel/feels} lucky to have such a kind cat as their mate.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [
-                "mates"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": [],
-            "trait": [
-                "compassionate",
-                "loving",
-                "thoughtful"
-            ]
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "newleaf"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c sits still as r_c helps remove some leftover Leaf-bare fluff from the back of {PRONOUN/m_c/poss} neck.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [
-                "mates"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "platonic"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "clan_kits"
-        ],
-        "weight": 20,
-        "event_text": "m_c listens bashfully as r_c tells the story of how {PRONOUN/r_c/subject} fell in love with {PRONOUN/r_c/poss} mate to a group of starry-eyed kits.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [
-                "mates"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "romantic",
-                    "platonic"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c and r_c are so cuddled up and cozy in their nest they almost miss the dawn patrol.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [
-                "mates"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "romantic",
-                    "platonic"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "leaf-fall"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "r_c gives m_c the prettiest fallen leaf {PRONOUN/r_c/subject} can find. m_c wears it with pride.",
-        "new_accessory": [
-            "MAPLE LEAF"
-        ],
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [
-                "mates"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "romantic",
-                    "platonic"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c and r_c spend the evening chasing cicadas around camp. m_c keeps a trophy of {PRONOUN/m_c/poss} catch on {PRONOUN/m_c/poss} pelt.",
-        "new_accessory": [
-            "CICADA WINGS"
-        ],
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [
-                "mates"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "platonic"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "It's tough working in such extreme heat. m_c and r_c spend their evening relaxing together and cooling down in the shade.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [
-                "mates"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "platonic"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "comfort",
-            "respect",
-            "clan_kits"
-        ],
-        "weight": 20,
-        "event_text": "m_c calls out to some eager kits, and after they have situated themselves in front of m_c, {PRONOUN/m_c/subject} {VERB/m_c/start/starts} telling the kits a thrilling story of times long past.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "skill": [
-                "STORY,1",
-                "LORE,2"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "Any"
-        ],
-        "season": [
-            "leaf-fall"
-        ],
-        "tags": [
-            "clan_kits"
-        ],
-        "weight": 20,
-        "event_text": "The older cats look fondly upon the kits who are dashing in and out of leaf piles at the edge of camp.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c went for a long walk this morning, deep in thought.",
-        "m_c": {
-            "age": [],
-            "status": []
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "The world around {PRONOUN/m_c/object} feels smaller lately; m_c looks out at the horizon and yearns for something unnameable.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "trait": [
-                "adventurous",
-                "daring"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c considers, as {PRONOUN/m_c/subject} {VERB/m_c/look/looks} out over the Clan, if perhaps this isn't where {PRONOUN/m_c/subject} {VERB/m_c/belong/belongs}.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "trait": [
-                "adventurous",
-                "daring",
-                "insecure",
-                "nervous"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "skill_trait_required"
-        ],
-        "weight": 20,
-        "event_text": "m_c's dreams are filled with flashing teeth and blood-scent. {PRONOUN/m_c/subject/CAP} {VERB/m_c/wake/wakes} up screaming.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "skill": [
-                "DARK,0"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "skill_trait_required"
-        ],
-        "weight": 20,
-        "event_text": "m_c thought {PRONOUN/m_c/subject} saw a familar wispy form lingering at the edge of camp, but the ghost disappeared before {PRONOUN/m_c/subject} could be sure.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "skill": [
-                "GHOST,0"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "murder_reveal"
-        ],
-        "weight": 20,
-        "event_text": "r_c overheard m_c muttering in {PRONOUN/m_c/poss} sleep, claws slashing at the air. {PRONOUN/m_c/poss/CAP} muttering confirms what r_c always suspected -  m_c was the one responsible for mur_c's death.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "murder_reveal"
-        ],
-        "weight": 20,
-        "event_text": "m_c can't keep this secret anymore. When {PRONOUN/m_c/subject} {VERB/m_c/find/finds} {PRONOUN/m_c/self} alone with r_c, {PRONOUN/m_c/subject} {VERB/m_c/tell/tells} the story of mur_c's death.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "murder_reveal"
-        ],
-        "weight": 20,
-        "event_text": "m_c laughs menacingly as r_c accuses {PRONOUN/m_c/object} of murdering mur_c. So what if {PRONOUN/m_c/subject} did? What is r_c going to do about it?",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
-            "trait": [
-                "bloodthirsty"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "murder_reveal"
-        ],
-        "weight": 20,
-        "event_text": "r_c gathers all the courage {PRONOUN/r_c/subject} {VERB/r_c/have/has} and quietly tells m_c {PRONOUN/r_c/subject} {VERB/r_c/know/knows} what {PRONOUN/m_c/subject} did to mur_c. m_c glares menacingly and threatens r_c with the same fate if {PRONOUN/r_c/subject} {VERB/r_c/don't/doesn't} keep {PRONOUN/r_c/poss} mouth shut.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
-            "trait": [
-                "bloodthirsty"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "murder_reveal"
-        ],
-        "weight": 20,
-        "event_text": "r_c avoids m_c at all costs after accidentally witnessing mur_c's murder. r_c knows {PRONOUN/r_c/subject} can't keep it a secret but is terrified of what m_c might do.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
-            "trait": [
-                "bloodthirsty"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "murder_reveal"
-        ],
-        "weight": 20,
-        "event_text": "m_c doesn't change expressions in the slightest when r_c accuses {PRONOUN/m_c/object} of murdering mur_c. Who cares?",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
-            "trait": [
-                "cold"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "murder_reveal"
-        ],
-        "weight": 20,
-        "event_text": "m_c's cold eyes don't blink when {PRONOUN/m_c/subject} {VERB/m_c/are/is} accused of murdering mur_c, and only simply states that the Clan is better off without mur_c anyways.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
-            "trait": [
-                "cold"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "murder_reveal"
-        ],
-        "weight": 20,
-        "event_text": "m_c boldly confesses to the entire Clan that {PRONOUN/m_c/subject} killed mur_c. m_c claims that mur_c deserved to pay for what {PRONOUN/mur_c/subject} did.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
-            "trait": [
-                "vengeful"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "murder_reveal"
-        ],
-        "weight": 20,
-        "event_text": "m_c is truthful when r_c questions {PRONOUN/m_c/object} about mur_c's strange death. m_c claims that mur_c deserved to die after what {PRONOUN/mur_c/subject} did to m_c.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
-            "trait": [
-                "vengeful"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "murder_reveal"
-        ],
-        "weight": 20,
-        "event_text": "r_c is stunned when {PRONOUN/r_c/subject} {VERB/r_c/discover/discovers} m_c carelessly bragging about killing mur_c to a wandering loner.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
-            "trait": [
-                "oblivious"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "murder_reveal"
-        ],
-        "weight": 20,
-        "event_text": "m_c can't keep this secret anymore. {PRONOUN/m_c/subject/CAP} {VERB/m_c/request/requests} a Clan meeting, where {PRONOUN/m_c/subject} {VERB/m_c/reveal/reveals} the terrible secret {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} kept.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
-            "trait": [
-                "righteous",
-                "bold",
-                "strict"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c is brought back to camp after wandering off.",
-        "m_c": {
-            "age": [
-                "senior",
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "elder"
-            ],
-            "status": []
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c calls the younger cats to {PRONOUN/m_c/poss} den to tell stories of the Clan's past.",
-        "m_c": {
-            "age": [
-                "senior",
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "elder"
-            ],
-            "status": [],
-            "skill": [
-                "STORY,1"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c speaks to r_c about how to better defend the camp.",
-        "m_c": {
-            "age": [
-                "senior",
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "elder"
-            ],
-            "status": [],
-            "relationship_status": [],
-            "skill": [
-                "INSIGHTFUL,1"
-            ]
-        },
-        "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c helps reinforce the dens in the camp while the rest of the camp is on patrol.",
-        "m_c": {
-            "age": [
-                "senior",
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "elder"
-            ],
-            "status": [],
-            "skill": [
-                "CAMP,2"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c places small feathers and shining stones near the nest of each Clanmate while they're on patrol.",
-        "m_c": {
-            "age": [
-                "senior",
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "elder"
-            ],
-            "status": [],
-            "skill": [
-                "CAMP,2"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c keeps an eye on the camp while the warriors are on patrol.",
-        "m_c": {
-            "age": [
-                "senior",
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "elder"
-            ],
-            "status": [],
-            "skill": [
-                "CAMP,3"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c disappears for a few days, then returns to camp with a acc_singular around {PRONOUN/m_c/poss} neck.",
-        "new_accessory": [
-            "COLLAR"
-        ],
-        "m_c": {
-            "age": [
-                "senior",
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "elder"
-            ],
-            "status": []
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c awakens with multiple objects stacked on {PRONOUN/m_c/object}, and the sound of giggling cats in the distance.",
-        "m_c": {
-            "age": [
-                "senior",
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "elder"
-            ],
-            "status": []
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "Any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "clan_kits"
-        ],
-        "weight": 20,
-        "event_text": "m_c calls out to some eager kits, and after they have situated themselves in front of m_c, {PRONOUN/m_c/subject} {VERB/m_c/start/starts} telling the kits a thrilling story of times long past.",
-        "m_c": {
-            "age": [
-                "senior",
-                "adolescent",
-                "young adult",
-                "adult",
-                "senior adult",
-                "elder"
-            ],
-            "status": [],
-            "skill": [
-                "STORY,1",
-                "LORE,2"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "comfort",
-                    "respect"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c and r_c take a late night patrol out of camp to watch the sun rise.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "romantic",
-                    "platonic",
-                    "comfort"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c and r_c take an early evening patrol out of camp to watch the moon rise.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ],
-            "relationship_status": []
-        },
-        "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "mututal": true,
-                "values": [
-                    "romantic",
-                    "platonic",
-                    "comfort"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c encourages r_c to play in the snow with {PRONOUN/m_c/object} during a patrol.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ],
-            "relationship_status": [],
-            "trait": "playful"
-        },
-        "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [
-                    "comfort"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c gifts {PRONOUN/m_c/poss} beloved r_c with a acc_singular to wear in {PRONOUN/m_c/poss} pelt.",
-        "new_accessory": [
-            "WILD",
-            "PLANT"
-        ],
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ],
-            "relationship_status": [
-                "mates"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [
-                    "romantic",
-                    "comfort",
-                    "trust"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c gives r_c a acc_singular to make up for a bad fight between them.",
-        "new_accessory": [
-            "WILD",
-            "PLANT"
-        ],
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ],
-            "relationship_status": [
-                "mates"
-            ]
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "relationships": [
-            {
-                "values": [
-                    "romantic",
-                    "comfort",
-                    "trust"
-                ],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c disappears for a few days, then returns to camp with a acc_singular around {PRONOUN/m_c/poss} neck.",
-        "new_accessory": [
-            "COLLAR"
-        ],
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen speaking calmly to a cat from o_c.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        },
-        "other_clan": {
-            "current_rep": [],
-            "changed": 5
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen arguing, and borderline-fighting, with a cat from o_c.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        },
-        "other_clan": {
-            "current_rep": [],
-            "changed": -5
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen racing along the border with {PRONOUN/m_c/poss} rival from o_c.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        },
-        "other_clan": {
-            "current_rep": [],
-            "changed": 0
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was loitering around o_c's border, looking for a specific cat.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        },
-        "other_clan": {
-            "current_rep": [],
-            "changed": 0
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen talking calmly to a loner, before both cats went their separate ways.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen touching noses with someone from o_c. Scandalous!",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        },
-        "other_clan": {
-            "current_rep": [],
-            "changed": 0
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen touching noses with a loner. Scandalous!",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen arguing, and borderline-fighting, with a loner.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen in a very serious conversation with a kittypet, who ran away when another patrol approached.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen chasing a kittypet off of the territory.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen chasing a rogue off of the territory.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen touching noses with a rogue. Scandalous!",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen playing with a kittypet over the border.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen taking food from a Twoleg!",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was caught sharing prey with a rogue, who was chased off by a patrol.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was caught sharing prey with a kittypet, who was chased off by a patrol.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        }
-    },
-    {
-        "event_id": "gen_misc_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was seen touching noses with a kittypet. Scandalous!",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [
-                "warrior",
-                "deputy",
-                "leader"
-            ]
-        }
+      "event_id": "gen_misc_any_apprentice1",
+      "biome": ["any"],
+      "camp": ["any"],
+      "season": ["any"],
+      "weight": 20,
+      "event_text": "m_c sneaks out of camp with r_c.",
+      "m_c": {
+          "age": ["adolescent"],
+          "status": ["apprentice"]
+      },
+      "r_c": {
+        "age": ["adolescent"],
+        "status": ["apprentice"]
+      },
+      "relationships": [
+          {
+              "values": ["trust", "platonic"],
+              "amount": 10
+          }
+      ]
+  },
+  {
+    "event_id": "gen_misc_any_apprentice2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "m_c and r_c sneak out of camp to see the sun rise.",
+    "m_c": {
+        "age": ["adolescent"],
+        "status": ["apprentice"]
+    },
+    "r_c": {
+        "age": ["adolescent"],
+        "status": ["apprentice"]
+    },
+    "relationships": [
+        {
+            "mututal": true,
+            "values": ["platonic", "comfort", "trust"],
+            "amount": 5
+        }
+    ]
+  },
+  {
+    "event_id": "gen_misc_any_apprentice3",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "m_c and r_c sneak out of camp to see the moon rise.",
+    "m_c": {
+      "age": ["adolescent"],
+      "status": ["apprentice"]
+    },
+    "r_c": {
+      "age": ["adolescent"],
+      "status": ["apprentice"]
+    },
+    "relationships": [
+        {
+          "mututal": true,
+          "values": ["platonic", "comfort", "trust"],
+          "amount": 5
+        }
+    ]
+  },
+  {
+    "event_id": "gen_misc_any_apprentice4",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "m_c and r_c try to sneak out of camp, but are caught by their mentors.",
+    "m_c": {
+      "age": ["adolescent"],
+      "status": ["apprentice"]
+    },
+    "r_c": {
+      "age": ["adolescent"],
+      "status": ["apprentice"]
+    },
+    "relationships": [
+        {
+          "mututal": true,
+          "values": ["platonic", "trust"],
+          "amount": 10
+        }
+    ]
+  },
+  {
+    "event_id": "gen_misc_multi_apprentice1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["newleaf", "greenleaf", "leaf-fall"],
+    "weight": 20,
+    "event_text": "m_c and r_c were practicing climbing when they found a nest of strange eggs.",
+    "m_c": {
+        "age": ["adolescent"],
+        "status": ["apprentice"]
+    },
+    "r_c": {
+        "age": ["adolescent"],
+        "status": ["apprentice"]
+    },
+    "relationships": [
+        {
+            "mututal": true,
+            "values": ["platonic", "trust"],
+            "amount": 10
+        }
+    ]
+  },
+  {
+    "event_id": "gen_misc_multi_apprentice2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["newleaf", "greenleaf", "leaf-fall"],
+    "weight": 20,
+    "event_text": "m_c and r_c sneak out of camp to go bird watching.",
+    "m_c": {
+        "age": ["adolescent"],
+        "status": ["apprentice"]
+    },
+    "r_c": {
+        "age": ["adolescent"],
+        "status": ["apprentice"]
+    },
+    "relationships": [
+        {
+            "mututal": true,
+            "values": ["platonic", "trust"],
+            "amount": 10
+        }
+    ]
+  },
+  {
+    "event_id": "gen_misc_leaffall_apprentice1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["leaf-fall"],
+    "weight": 20,
+    "event_text": "m_c and r_c play in the fallen leaves outside of camp.",
+    "m_c": {
+        "age": ["adolescent"],
+        "status": ["apprentice"]
+    },
+    "r_c": {
+        "age": ["adolescent"],
+        "status": ["apprentice"]
+    },
+    "relationships": [
+        {
+            "mututal": true,
+            "values": ["platonic", "trust"],
+            "amount": 10
+        }
+    ]
+  },
+  {
+    "event_id": "gen_misc_leafbare_apprentice1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["leaf-bare"],
+    "weight": 20,
+    "event_text": "m_c and r_c play in the snow outside of camp.",
+    "m_c": {
+        "age": ["adolescent"],
+        "status": ["apprentice"]
+    },
+    "r_c": {
+        "age": ["adolescent"],
+        "status": ["apprentice"]
+    },
+    "relationships": [
+        {
+            "mututal": true,
+            "values": ["platonic", "trust"],
+            "amount": 10
+        }
+    ]
+  },
+  {
+    "event_id": "gen_misc_accessoryapprentice1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "m_c and r_c were chatting about their day and the chores they finished when r_c mentioned {PRONOUN/r_c/subject} liked the smell of wild fruit. m_c decides to wear acc_plural on {PRONOUN/m_c/poss} pelt, hoping that r_c notices {PRONOUN/m_c/object}.",
+    "new_accessory": ["BLUE BERRIES", "HOLLY"],
+    "m_c": {
+      "age": ["adolescent"],
+      "status": ["apprentice"],
+      "relationship_status": ["can_romance"]
+    },
+    "r_c": {
+      "age": ["adolescent"],
+      "status": ["apprentice"],
+      "relationship_status": ["can_romance"]
+    },
+    "relationships": [
+        {
+          "mututal": true,
+          "values": ["romantic", "comfort", "trust", "respect"],
+          "amount": 10
+        }
+    ]
+  },
+  {
+    "event_id": "gen_misc_any_accessoryapprentice2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "m_c, for the umpteenth time, hears r_c complaining about the dry rye stalks underneath {PRONOUN/r_c/poss} paws when {PRONOUN/r_c/subject} {VERB/r_c/finish/finishes} cleaning the elders' den and got an idea. The next day, m_c adorns {PRONOUN/m_c/poss} pelt with acc_plural.",
+    "new_accessory": ["RYE STALK"],
+    "m_c": {
+      "age": ["adolescent"],
+      "status": ["apprentice"]
+    },
+    "r_c": {
+      "age": ["adolescent"],
+      "status": ["apprentice"]
     }
+  },
+  {
+    "event_id": "gen_misc_leafbare_accessoryapprentice",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["leaf-bare"],
+    "weight": 20,
+    "event_text": "m_c gets dared to hunt outside in the snow alone, and returns with acc_singular in {PRONOUN/m_c/poss} pelt.",
+    "new_accessory": ["WILD", "PLANT"],
+    "m_c": {
+      "age": ["adolescent"],
+      "status": ["apprentice"]
+    }
+  },
+  {
+    "event_id": "gen_misc_any_accessoryapprenticekit1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "m_c is nearly blindsided by r_c as {PRONOUN/r_c/subject} {VERB/r_c/walk/walks} into camp after a long training day, listening to the kit squeak about a type of feather. r_c leads m_c to the nursery, where {PRONOUN/r_c/subject} carefully put acc_plural in m_c's fur.",
+    "new_accessory": ["BLUE FEATHERS"],
+    "m_c": {
+        "age": ["adolescent"],
+        "status": ["apprentice"]
+    },
+    "r_c": {
+        "age": ["kitten"]
+    },
+    "relationships": [
+        {
+            "values": ["platonic","comfort"],
+            "amount": 5
+        }
+    ]
+  },
+  {
+    "event_id": "gen_misc_war_any_apprentice1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags":["war"],
+    "weight": 10,
+    "event_text": "m_c is struggling to cope with the violence and chaos of war surrounding {PRONOUN/m_c/object}, finding it difficult to wake up in the morning due to the stress and strain of constant battle training.",
+    "m_c": {
+        "age": ["adolescent"],
+        "status": ["apprentice"],
+        "trait": ["nervous", "lonesome", "playful", "careful", "compassionate", "loving", "insecure"]
+    },
+    "other_clan": {
+        "current_rep": ["hostile"],
+        "changed": -5
+    }
+  },
+  {
+    "event_id": "gen_misc_war_any_apprentice2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags":["war"],
+    "weight": 20,
+    "event_text": "m_c feels like {PRONOUN/m_c/subject} might be growing up too fast in the midst of war.",
+    "m_c": {
+        "age": ["adolescent"],
+        "status": ["apprentice"]
+    }
+  },
+  {
+    "event_id": "gen_misc_any_scandalous_kittypet1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 15,
+    "event_text": "m_c was caught sharing prey with a kittypet, who was chased off by a patrol.",
+    "m_c": {
+        "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+        "status": ["apprentice", "warrior", "deputy", "leader", "medicine cat"]
+    },
+    "outsider": {
+      "current_rep": ["any"],
+      "changed": -5
+    }
+  },
+  {
+    "event_id": "gen_misc_any_scandalous_kittypet2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 15,
+    "event_text": "m_c was seen touching noses with a kittypet. Scandalous!",
+    "m_c": {
+        "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+        "status": ["apprentice", "warrior", "deputy", "leader", "medicine cat"]
+    },
+    "outsider": {
+      "current_rep": ["any"],
+      "changed": 5
+    }
+  },
+  {
+    "event_id": "gen_misc_any_scandalous_kittypet3",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 15,
+    "event_text": "m_c was seen playing with a kittypet over the border.",
+    "m_c": {
+        "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+        "status": ["apprentice", "warrior", "deputy", "leader", "medicine cat"]
+    },
+    "outsider": {
+      "current_rep": ["any"],
+      "changed": 7
+    }
+  },
+  {
+    "event_id": "gen_misc_any_scandalous_kittypet4",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 15,
+    "event_text": "m_c was seen chasing a kittypet off of the territory.",
+    "m_c": {
+        "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+        "status": ["apprentice", "warrior", "deputy", "leader", "medicine cat"]
+    },
+    "outsider": {
+      "current_rep": ["any"],
+      "changed": -5
+    }
+  },
+  {
+    "event_id": "gen_misc_any_scandalous_kittypet5",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 15,
+    "event_text": "m_c was seen in a very serious conversation with a kittypet, who ran away when another patrol approached.",
+    "m_c": {
+        "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+        "status": ["apprentice", "warrior", "deputy", "leader", "medicine cat"]
+    }
+  },
+  {
+    "event_id": "gen_misc_any_scandalous_other_clan1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "m_c was seen touching noses with someone from o_c. Scandalous!",
+    "m_c": {
+        "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+        "status": ["apprentice", "warrior", "deputy", "leader", "medicine cat"]
+    },
+    "other_clan": {
+      "current_rep": ["any"],
+      "changed": 5
+    }
+  },
+  {
+    "event_id": "gen_misc_any_scandalous_other_clan2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "m_c was loitering around o_c's border, looking for a specific cat.",
+    "m_c": {
+        "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+        "status": ["apprentice", "warrior", "deputy", "leader", "medicine cat"]
+    }
+  },
+  {
+    "event_id": "gen_misc_any_scandalous_other_clan3",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "m_c was seen racing along the border with {PRONOUN/m_c/poss} rival from o_c.",
+    "m_c": {
+        "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+        "status": ["apprentice", "warrior", "deputy", "leader", "medicine cat"]
+    },
+    "other_clan": {
+      "current_rep": ["any"],
+      "changed": 10
+    }
+  },    
+  {
+    "event_id": "gen_misc_any_scandalous_other_clan4",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": [],
+    "weight": 10,
+    "event_text": "m_c was seen arguing, and borderline-fighting, with a cat from o_c.",
+    "m_c": {
+        "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+        "status": ["apprentice", "warrior", "deputy", "leader", "medicine cat"]
+    },
+    "other_clan": {
+      "current_rep": ["any"],
+      "changed": -5
+    }
+  },
+  {
+    "event_id": "gen_misc_any_scandalous_other_clan5",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "m_c was seen speaking calmly to a cat from o_c.",
+    "m_c": {
+        "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+        "status": ["apprentice", "warrior", "deputy", "leader", "medicine cat"]
+    },
+    "other_clan": {
+      "current_rep": ["any"],
+      "changed": 10
+    }
+  },
+  {
+    "event_id": "gen_misc_any_scandalous_loner1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 15,
+    "event_text": "m_c was seen arguing, and borderline-fighting, with a loner.",
+    "m_c": {
+        "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+        "status": ["apprentice", "warrior", "deputy", "leader", "medicine cat"]
+    },
+    "outsider": {
+      "current_rep": ["any"],
+      "changed": -5
+    }
+  },
+  {
+    "event_id": "gen_misc_any_scandalous_loner2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 15,
+    "event_text": "m_c was seen touching noses with a loner. Scandalous!",
+    "m_c": {
+        "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+        "status": ["apprentice", "warrior", "deputy", "leader", "medicine cat"]
+    },
+    "outsider": {
+      "current_rep": ["any"],
+      "changed": 5
+    }
+  },
+  {
+    "event_id": "gen_misc_any_scandalous_loner3",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 15,
+    "event_text": "m_c was seen talking calmly to a loner, before both cats went their separate ways.",
+    "m_c": {
+        "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+        "status": ["apprentice", "warrior", "deputy", "leader", "medicine cat"]
+    }
+  },
+  {
+    "event_id": "gen_misc_any_scandalous1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 15,
+    "event_text": "m_c was seen taking food from a Twoleg!",
+    "m_c": {
+        "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+        "status": ["apprentice", "warrior", "deputy", "leader", "medicine cat"]
+    }
+  },
+  {
+    "event_id": "gen_misc_any_scandalous_rogue1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 15,
+    "event_text": "m_c was caught sharing prey with a rogue, who was chased off by a patrol.",
+    "m_c": {
+        "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+        "status": ["apprentice", "warrior", "deputy", "leader", "medicine cat"]
+    },
+    "outsider": {
+      "current_rep": ["any"],
+      "changed": 5
+    }
+  },
+  {
+    "event_id": "gen_misc_any_scandalous_rogue2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 15,
+    "event_text":  "m_c was seen touching noses with a rogue. Scandalous!",
+    "m_c": {
+        "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+        "status": ["apprentice", "warrior", "deputy", "leader", "medicine cat"]
+    },
+    "outsider": {
+      "current_rep": ["any"],
+      "changed": 5
+    }
+  },
+  {
+    "event_id": "gen_misc_any_scandalous_rogue3",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 15,
+    "event_text":"m_c was seen chasing a rogue off of the territory.",
+    "m_c": {
+        "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+        "status": ["apprentice", "warrior", "deputy", "leader", "medicine cat"]
+    },
+    "outsider": {
+      "current_rep": ["any"],
+      "changed": -5
+    }
+  },
+  {
+    "event_id": "gen_misc_any_wartraitmediator1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["war"],
+    "weight": 15,
+    "event_text": "m_c goes to o_c in an attempt to ease the tension of war between the Clans: it goes well, and o_c begins to draw back from c_n's territory!",
+    "m_c": {
+      "status":["mediator", "mediator apprentice"],
+      "skill": ["MEDIATOR,2", "MEDIATOR,3", "MEDIATOR,4"]
+    },
+    "other_clan": {
+      "changed": 5
+    }
+  },
+  {
+    "event_id": "gen_misc_any_wartraitmediator2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["war"],
+    "weight": 20,
+    "event_text": "m_c is checking in on every cat in the camp to make sure everyone is staying healthy in the midst of war.",
+    "m_c": {
+        "status": [
+            "mediator", "mediator apprentice"],
+        "trait": ["calm", "careful", "insecure", "lonesome", "loyal", "nervous", "compassionate", "faithful", "loving", "responsible", "thoughtful", "wise", "inquisitive", "childish", "playful"]
+    },
+    "relationships": [
+        {
+            "cats_from": ["clan"],
+            "cats_to": ["m_c"],
+            "mutual": false,
+            "values": ["trust", "trust"],
+            "amount": 5
+          }
+        ]
+  },
+  {
+    "event_id": "gen_misc_any_warmediator1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["war"],
+    "weight": 15,
+    "event_text": "m_c goes to o_c in an attempt to ease the tension of war between the Clans: it doesn't go well, and o_c further advances in c_n's territory.",
+    "m_c":{
+        "status":["mediator", "mediator apprentice"]
+    },
+    "other_clan": {
+      "changed": -5
+    }
+  },
+  {
+    "event_id": "gen_misc_any_mediatortoadult",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "m_c pulls r_c to the side, quietly asking {PRONOUN/r_c/object} abou {PRONOUN/r_c/poss} crush on a fellow Clanmate.",
+    "m_c":{
+        "status":["mediator", "mediator apprentice"]
+    },
+    "r_c": {
+      "age": ["young adult", "adult", "senior adult", "senior"],
+      "status": ["warrior", "mediator", "medicine cat", "deputy", "leader", "elder"],
+      "trait": ["nervous","insecure","grumpy"]
+    },
+    "relationships": [
+      {
+        "cats_from": ["r_c"],
+        "cats_to": ["m_c"],
+        "mutual": false,
+        "values": ["comfort", "trust"],
+        "amount": 5
+      },
+      {
+        "cats_from": ["r_c"],
+        "cats_to": ["m_c"],
+        "mutual": false,
+        "values": ["dislike"],
+        "amount": -5
+      }
+    ]
+  },
+  {
+    "event_id": "gen_misc_any_mediatorkit",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "m_c spots r_c looking a little bit lonely, and invites {PRONOUN/r_c/object} to watch as {PRONOUN/m_c/subject} {VERB/m_c/perform/performs} {PRONOUN/m_c/poss} duties.",
+    "m_c":{
+        "status": ["mediator", "mediator apprentice"]
+    },
+    "r_c": {
+      "age": ["kitten"],
+      "status": ["kitten"]
+    },
+    "relationships": [
+        {
+            "cats_from": ["r_c"],
+            "cats_to": ["m_c"],
+            "mutual": false,
+            "values": ["platonic", "trust"],
+            "amount": 10
+          },
+          {
+            "cats_from": ["r_c"],
+            "cats_to": ["m_c"],
+            "mutual": false,
+            "values": ["dislike"],
+            "amount": -5
+          }
+    ]
+  },
+  {
+    "event_id": "gen_misc_any_war_mediatorleader1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["war"],
+    "weight": 10,
+    "event_text": "m_c is giving r_c bad war advice on purpose.",
+    "m_c": {
+        "status": ["mediator", "mediator apprentice"],
+        "relationship_status": ["dislike_20"],
+        "trait": ["cunning"]
+    },
+    "r_c": {
+      "status": ["leader"],
+      "trait": ["bold", "charismatic","confident", "daring","righteous","ambitious","bloodthirsty","cold","fierce","shameless","strict", "troublesome", "vengeful", "sneaky", "strange"]
+    },
+    "relationships": [
+      {
+        "mutual": true,
+        "values": ["dislike"],
+        "amount": 10
+      },
+      {
+        "mutual": true,
+        "values": ["trust", "comfort"],
+        "amount": -10
+      }
+    ]
+  },
+  {
+    "event_id": "gen_misc_any_war_mediatorleader2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["war"],
+    "weight": 10,
+    "event_text": "m_c is conversing with r_c about ways to potentially end this war without bloodshed.",
+    "m_c":{
+        "status": ["mediator", "mediator apprentice"]
+    },
+    "r_c": {
+      "status": ["leader"],
+      "trait": ["calm","careful","insecure","lonesome","loyal","nervous","compassionate","faithful","loving","responsible","thoughtful","wise","inquisitive","childish","playful"]
+    },
+    "relationships": [
+      {
+        "cats_from": ["m_c"],
+        "cats_to": ["r_c"],
+        "mutual": true,
+        "values": ["trust"],
+        "amount": 5
+      }
+    ]
+  },
+  {
+    "event_id": "gen_misc_any_war_mediatorleader3",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["war"],
+    "weight": 10,
+    "event_text": "m_c is conversing with r_c about ways to potentially end this war- but not without bloodshed.",
+    "m_c":{
+        "status": ["mediator", "mediator apprentice"]
+    },
+    "r_c": {
+      "status": ["leader"],
+      "trait": ["bold", "charismatic","confident", "daring","righteous","ambitious","bloodthirsty","cold","fierce","shameless","strict", "troublesome", "vengeful", "sneaky", "strange"]
+    },
+    "relationships": [
+      {
+        "cats_from": ["m_c"],
+        "cats_to": ["r_c"],
+        "mutual": true,
+        "values": ["trust"],
+        "amount": -5
+      }
+    ]
+  },
+  {
+    "event_id": "gen_misc_any_medicinecatotherclan1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 15,
+    "event_text": "m_c visits the other medicine cats.",
+    "m_c": {
+        "age": ["young adult","adult","senior adult","senior"],
+        "status": ["medicine cat"]
+    },
+    "other_clan": {
+      "current_rep": ["any"],
+      "changed": 10
+    }
+  },
+  {
+    "event_id": "gen_misc_any_medicinecatotherclan2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 15,
+    "event_text": "m_c visits o_c to converse with their medicine cats about an omen StarClan sent.",
+    "m_c": {
+        "age": ["young adult","adult","senior adult","senior"],
+        "status": ["medicine cat"],
+        "skill": ["STAR,0", "CLAIRVOYANT,0", "OMEN,0", "DREAM,0"]
+      },
+    "other_clan": {
+      "current_rep": ["any"],
+      "changed": 10
+    }
+  },
+  {
+    "event_id": "gen_misc_any_medicinecatotherclan3",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 15,
+    "event_text": "m_c visits o_c to congratulate them on their new medicine cat.",
+    "m_c": {
+        "age": ["young adult","adult","senior adult","senior"],
+        "status": ["medicine cat"],
+        "skill": ["MEDIATOR,1"]
+      },
+    "other_clan": {
+      "current_rep": ["any"],
+      "changed": 10
+    }
+  },
+  {
+    "event_id": "gen_misc_ceremony_any_medicinecatacc1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["ceremony"],
+    "weight": 10,
+    "event_text": "r_c presents m_c with acc_plural as a congratulations.",
+    "new_accessory": ["WILD", "PLANT"],
+    "m_c": {
+        "status": ["medicine cat"]
+    },
+    "r_c": {
+        "status": ["medicine cat"]
+    },
+    "relationships": [
+      {
+        "mutual": true,
+        "values": ["platonic","comfort","trust"],
+        "amount": 5
+      },
+      {
+        "mutual": true,
+        "values": ["dislike"],
+        "amount": -5
+      }
+    ]
+  },
+  {
+    "event_id": "gen_misc_any_medicinecatleaderomen1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "m_c speaks to r_c about an omen {PRONOUN/m_c/subject} saw while on patrol recently.",
+    "m_c": {
+        "status": ["medicine cat"],
+        "skill": ["OMEN,0"]
+      },
+    "r_c": {
+      "status": ["leader"]
+    }
+},
+{
+    "event_id": "gen_misc_any_medicinecatmedcatomen1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "m_c speaks to r_c about a potential omen and what it means.",
+    "m_c": {
+        "status": ["medicine cat"],
+        "skill": ["OMEN,0"]
+      },
+    "r_c": {
+      "status": ["medicine cat"]
+    }
+},
+{
+    "event_id": "gen_misc_any_medicinecatdream1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["skill_trait_required"],
+    "weight": 10,
+    "event_text": "m_c walks into the dreams of {PRONOUN/m_c/poss} Clanmates while everyone sleeps.",
+    "m_c": {
+        "status": ["medicine cat"],
+        "skill": ["DREAM,2"]
+    }
+},
+{
+  "event_id": "gen_misc_any_medicinecatdream2",
+  "biome": ["any"],
+  "camp": ["any"],
+  "season": ["any"],
+  "tags": ["skill_trait_required"],
+  "weight": 10,
+  "event_text": "m_c tosses in {PRONOUN/m_c/poss} sleep as {PRONOUN/m_c/poss} dreamself pads through the thoughts of {PRONOUN/m_c/poss} Clanmates, picking up snippets of dream_list. {PRONOUN/m_c/subject/CAP} slowly {VERB/m_c/blink/blinks} awake, wondering whose dreams {PRONOUN/m_c/subject} walked in.",
+  "m_c": {
+      "status": ["medicine cat apprentice", "medicine cat"], 
+      "skill": ["DREAM,2"]
+  }
+},
+{
+    "event_id": "gen_misc_any_medicinecatclairvoy1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["skill_trait_required"],
+    "weight": 10,
+    "event_text": "m_c correctly warns the leader of an ambush, thanks to {PRONOUN/m_c/poss} clairvoyant nature.",
+    "m_c": {
+        "status": ["medicine cat"],
+        "skill": ["CLAIRVOYANT,2"]
+    }
+},
+{
+    "event_id": "gen_misc_any_medicinecatprophet1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "m_c spends {PRONOUN/m_c/poss} day communing with StarClan, attempting to figure out a recent prophecy.",
+    "m_c": {
+        "status":["medicine cat", "medicine cat apprentice"],
+        "skill": ["PROPHET,2"]
+    }
+},
+{
+    "event_id": "gen_misc_any_medicinecatelderlore1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "m_c has been worried that c_n will lose the knowledge r_c has gained through {PRONOUN/r_c/poss} long life, but by sitting with r_c and discussing {PRONOUN/r_c/poss} experiences, m_c will ensure the lessons learned in the past are never forgotten.",
+    "m_c": {
+        "status":["medicine cat"],
+        "skill": ["LORE,0"]
+    },
+    "r_c": {
+        "age": ["senior"],
+        "status": ["elder"]
+    }
+},
+
+{
+    "event_id": "gen_misc_any_medicinecatscandolous1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "m_c was seen loudly bickering with the medicine cat of o_c.",
+    "m_c":{ 
+        "status": ["medicine cat"]
+    },
+    "other_clan": {
+      "current_rep": ["any"],
+      "changed": -5
+    }
+},
+{
+    "event_id": "gen_misc_any_medicinecatscandolous2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "m_c was seen talking with a traveling loner healer on the border.",
+    "m_c":{
+        "status": ["medicine cat"]
+    }
+},
+{
+    "event_id": "gen_misc_any_medicinecatwar1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["war"],
+    "weight": 10,
+    "event_text": "m_c's knowledge of herbs and healing is being put to the test, with injuries becoming more severe in the midst of war.",
+    "m_c": {
+        "status": ["medicine cat", "medicine cat apprentice"]
+    }
+},
+{
+    "event_id": "gen_misc_any_medicinecatwar2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["war"],
+    "weight": 10,
+    "event_text": "m_c watches every little thing around {PRONOUN/m_c/object} for any omen that indicates what the Clan should do in the war. The losses weigh heavy on the hearts of every cat.",
+    "m_c": {
+        "status": ["medicine cat apprentice", "medicine cat"],
+        "skill": ["OMEN,0"]
+    }
+},
+{
+    "event_id": "gen_misc_any_medicinecatwar3",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["war"],
+    "weight": 10,
+    "event_text": "m_c preps battle herbs into small bundles to rush to the battlefield in case of severe injuries.",
+    "m_c":{
+        "status": ["medicine cat apprentice", "medicine cat"]
+    }
+},
+{
+  "event_id": "gen_misc_any_medcatwar4",
+  "biome": ["any"],
+  "camp": ["any"],
+  "season": ["any"],
+  "tags": ["war"],
+  "weight": 10,
+  "event_text": "c_n is in a badly need of herbs, and m_c knows it, but can't bring {PRONOUN/m_c/self} to leave {PRONOUN/m_c/poss} patients' side.",
+  "m_c": {
+      "status": ["medicine cat", "medicine cat apprentice"]
+  }
+},
+{
+    "event_id": "gen_misc_leafbare_medicinecatwar1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["leafbare"],
+    "tags": ["war"],
+    "weight": 10,
+    "event_text":"m_c hopes to find the herbs that c_n needs in the war, and goes to look for them even in this leafbare's harsh weather.",
+    "m_c": {
+        "status": ["medicine cat apprentice", "medicine cat"]
+    }
+},
+
+{
+    "event_id": "gen_misc_any_medicinecatmedcatapp1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 5,
+    "event_text": "m_c is getting increasingly annoyed with r_c because {PRONOUN/r_c/subject} {VERB/r_c/keep/keeps} bothering {PRONOUN/m_c/object} about the most trivial of wounds and aches.",
+    "m_c":{
+        "status":["medicine cat"]
+    },
+    "r_c": {
+      "status": ["medicine cat apprentice"]
+    },
+    "relationships": [
+      {
+        "cats_from": ["m_c"],
+        "cats_to": ["r_c"],
+        "mutual": false,
+        "values": ["dislike"],
+        "amount": 10
+      }
+    ]
+  },
+  {
+    "event_id": "gen_misc_any_elder1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "m_c is brought back to camp after wandering off.",
+    "m_c": {
+        "status":["elder"],
+      "age": ["senior"]
+    }
+  },
+  {
+    "event_id": "gen_misc_any_elder2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "m_c awakens with multiple objects stacked on {PRONOUN/m_c/object}, and the sound of giggling cats in the distance.",
+    "m_c": {
+        "status":["elder"]
+    }
+  },
+  {
+    "event_id": "gen_misc_any_insightfulelderleader1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 15,
+    "event_text": "m_c speaks to r_c about how to better defend the camp.",
+    "m_c": {
+        "status":["elder"],
+        "skill": ["INSIGHTFUL,1"]
+    },
+    "r_c": {
+        "status": ["leader"]
+    }
+  },
+  {
+    "event_id": "gen_misc_any_campelder1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "m_c helps reinforce the dens in the camp while the rest of the camp is on patrol.",
+    "m_c": {
+        "status":["elder"],
+      "skill": ["CAMP,2"]
+    }
+  },
+  {
+    "event_id": "gen_misc_any_campelder2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "m_c places small feathers and shining stones near the nest of each Clanmate while they're on patrol.",
+    "m_c": {
+        "status":["elder"],
+      "skill": ["CAMP,2"]
+    }
+  },
+  {
+    "event_id": "gen_misc_any_campelder3",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 15,
+    "event_text": "m_c keeps an eye on the camp while the warriors are on patrol.",
+    "m_c": {
+        "status":["elder"],
+      "skill": ["CAMP,3"]
+    }
+  },
+  {
+    "event_id": "gen_misc_any_storyelder1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "m_c calls the younger cats to {PRONOUN/m_c/poss} den to tell stories of the Clan's past.",
+    "m_c": {
+        "status":["elder"],
+      "skill": ["STORY,1"]
+    }
+  },
+  {
+    "event_id": "gen_misc_any_storyelder2",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "tags": ["clan_kits"],
+        "weight": 15,
+        "event_text": "m_c calls out to some eager kits, and after they have situated themselves in front of m_c, {PRONOUN/m_c/subject} {VERB/m_c/start/starts} telling the kits a thrilling story of times long past.",
+        "m_c": {
+          "age": ["senior", "adolescent","young adult", "adult","senior adult"],
+          "skill": ["STORY,1","LORE,2"]
+        },
+        "relationships": [
+          {
+            "cats_from": ["clan"],
+            "cats_to": ["m_c"],
+            "mutual": false,
+            "values": ["comfort","respect"],
+            "amount": 10
+          }
+        ]
+  },
+  {
+    "event_id": "gen_misc_any_retiredeputy1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 15,
+    "event_text": "m_c thinks about retiring from being deputy.",
+    "m_c": {
+        "status": ["deputy"],
+        "age": ["senior adult", "senior"]
+    }
+  },
+
+
+  {
+    "event_id": "gen_misc_any_otherclandeputy1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "m_c travels to o_c to bring them an important message.",
+    "m_c":{
+        "status": ["medicine cat", "deputy"]
+    },
+    "other_clan": {
+      "current_rep": ["any"],
+      "changed": 5
+    }
+  },
+  {
+    "event_id": "gen_misc_any_otherclandeputy2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "m_c travels to the other Clans to bring them an important message.",
+    "m_c":{
+        "status": ["medicine cat", "deputy"]
+    },
+    "other_clan": {
+      "current_rep": ["any"],
+      "changed": 5
+    }
+  },
+  {
+    "event_id": "gen_misc_any_wardeputy1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["war"],
+    "weight": 10,
+    "event_text": "As the deputy, m_c is doing {PRONOUN/m_c/poss} best to prepare for leadership in the case that the worst happens.",
+    "m_c":{
+        "status": ["deputy"]
+    }
+  },
+  {
+    "event_id": "gen_misc_any_warmultitraitdeputyleader1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["war"],
+    "weight": 5,
+    "event_text": "m_c is struggling to accept the fact that {PRONOUN/m_c/subject} may have to step up as leader if r_c loses {PRONOUN/r_c/poss} last life.",
+    "m_c": {
+        "status": ["deputy"],
+        "trait": ["insecure","lonesome", "nervous"]
+      },
+      "r_c": {
+        "status": ["leader"]
+      }
+  },
+  {
+    "event_id": "gen_misc_any_warmultitraitdeputyleader2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["war"],
+    "weight": 10,
+    "event_text": "m_c is struggling to accept the fact that {PRONOUN/m_c/subject} may have to step up as leader if r_c loses {PRONOUN/r_c/poss} last life. How could {PRONOUN/m_c/subject} {VERB/m_c/go/goes} on without {PRONOUN/m_c/poss} beloved leader? How difficult will it to be to lead in {PRONOUN/r_c/poss} stead?",
+    "m_c": {
+        "status": ["deputy"],
+        "trait": ["insecure","lonesome", "nervous"]
+      },
+      "r_c": {
+        "status": ["leader"]
+      },
+    "relationships": [
+      {
+        "cats_from": ["m_c"],
+        "cats_to": ["r_c"],
+        "mutual": false,
+        "values": ["platonic", "respect", "trust"],
+        "amount": 10
+      }
+    ]
+  },
+  {
+    "event_id": "gen_misc_any_wardeputyelder1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["war"],
+    "weight": 10,
+    "event_text": "m_c is heavily relying on the tactical advice and experience of the elders, namely r_c.",
+    "m_c": {
+        "status": ["deputy"],
+        "trait": ["insecure","lonesome", "nervous"]
+      },
+      "r_c": {
+        "status": ["elder"],
+        "skill": ["INSIGHTFUL,1","TEACHER,3", "CLEVER,3", "CAMP,3"]
+      },
+    "relationships": [
+      {
+        "cats_from": ["m_c"],
+        "cats_to": ["r_c"],
+        "mutual": false,
+        "values": ["respect", "trust"],
+        "amount": 10
+      }
+    ]
+  },
+  {
+    "event_id": "gen_misc_any_lowlivesleader1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["low_lives"],
+    "weight": 10,
+    "event_text": "m_c thinks about retiring.",
+    "m_c":{
+      "status":["leader"]
+    }
+  },
+  {
+    "event_id": "gen_misc_any_lowlivesleader2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["low_lives"],
+    "weight": 10,
+    "event_text": "m_c confesses {PRONOUN/m_c/subject} {VERB/m_c/don't/doesn't} have many lives left.",
+    "m_c":{
+      "status":["leader"]
+    }
+  },
+  {
+    "event_id": "gen_misc_any_leader1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "m_c feels as though the responsibility of leadership is crushing {PRONOUN/m_c/object}.",
+    "m_c":{
+      "status":["leader"]
+    }
+  },
+  {
+    "event_id": "gen_misc_any_leader2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "m_c calls a Clan meeting to give an important announcement.",
+    "m_c":{
+      "status":["leader"]
+    }
+  },
+  {
+    "event_id": "gen_misc_any_warleader1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["war"],
+    "weight": 10,
+    "event_text": "m_c feels burdened with the weight of {PRONOUN/m_c/poss} decisions, knowing that every choice they make could mean the difference between victory and defeat.",
+    "m_c":{
+      "status":["leader"]
+    }
+},
+{
+    "event_id": "gen_misc_any_warleader2",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["war"],
+    "weight": 10,
+    "event_text": "m_c's relationships with {PRONOUN/m_c/poss} Clanmates are strained, with some questioning {PRONOUN/m_c/poss} decisions and others relying on {PRONOUN/m_c/object} more heavily than ever.",
+    "m_c":{
+      "status":["leader"]
+    }
+},
+{
+    "event_id": "gen_misc_any_warleader3",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["war"],
+    "weight": 10,
+    "event_text": "m_c is forced to be a symbol of strength and unity for {PRONOUN/m_c/poss} Clan, even in the face of {PRONOUN/m_c/poss} own doubts and fears.",
+    "m_c":{
+      "status": ["leader"]
+    }
+},
+{
+    "event_id": "gen_misc_any_leaderapprentice1",
+    "biome": ["any"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 20,
+    "event_text": "m_c assesses r_c's progress.",
+    "m_c":{
+      "status":["leader"]
+    },
+    "r_c": {
+      "status": ["apprentice", "mediator apprentice", "medicine cat apprentice"]
+    }
+  }
 ]

--- a/resources/dicts/events/misc_events/mountainous.json
+++ b/resources/dicts/events/misc_events/mountainous.json
@@ -1,42 +1,46 @@
 [
   {
-    "event_id": "mtn_misc_war_any_apps1",
+    "event_id": "mtn_misc_war_anyapps1",
     "biome": ["mountainous"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["war", "clan_apps"],
+    "sub_type": ["war"],
+    "tags": ["clan_apps"],
     "weight": 15,
     "event_text": "The apprentices of the Clan are taking special strength training to learn how to weaponize stones and boulders in the mountain landscape.",
     "m_c": {
+      "age": ["any"],
       "status": ["apprentice"]
     }
   },
   {
-    "event_id": "mtn_misc_any_prophecymedcatprophet1",
+    "event_id": "mtn_misc_anyprophecymedcatprophet1",
     "biome": ["mountainous"],
     "camp": ["any"],
     "season": ["any"],
     "weight": 10,
     "event_text": "As a storm rages across the mountain outside, m_c is tucked up in the medicine cat den, {PRONOUN/m_c/poss} sleep anything but restful. {PRONOUN/m_c/subject/CAP} {VERB/m_c/keep/keeps} seeing flashes of prophecy_list_sight. {PRONOUN/m_c/subject/CAP} {VERB/m_c/wake/wakes} with a shiver, wondering what {PRONOUN/m_c/poss} dreams mean for the Clan.",
     "m_c": {
+      "age": ["any"],
       "status": ["medicine cat", "medicine cat apprentice"],
-      "skill": ["PROPHET,2", "PROPHET,3"]
+      "skill": ["PROPHET,2"]
     }
   },
   {
-    "event_id": "mtn_misc_any_omenmedcatomen1",
+    "event_id": "mtn_misc_anyomenmedcatomen1",
     "biome": ["mountainous"],
     "camp": ["any"],
     "season": ["any"],
     "weight": 10,
     "event_text": "The things {PRONOUN/m_c/subject} saw today, omen_list_sight... m_c sits on an isolated mountain ledge, considering what the omens foretell.",
     "m_c": {
+      "age": ["any"],
       "status": ["medicine cat", "medicine cat apprentice"],
-      "skill": ["OMEN,2", "OMEN,3"]
+      "skill": ["OMEN,2"]
     }
   },
   {
-    "event_id": "mtn_misc_camptwo_leafbaremultilore1",
+    "event_id": "mtn_misc_camptwoleafbaremultilore1",
     "biome": ["mountainous"],
     "camp": ["camp2"],
     "season": ["leaf-bare"],
@@ -44,6 +48,7 @@
     "weight": 10,
     "event_text": "Through the long, cold night, m_c brings the young cats of the Clan with {PRONOUN/m_c/object} down the tunnels. {PRONOUN/m_c/poss} words paint an enchanting picture of the ancestors of c_n as {PRONOUN/m_c/subject} {VERB/m_c/point/points} out the red pawprints of long dead heroes and villains, telling the Clan's triumphs and failures.",
     "m_c": {
+      "age": ["any"],
       "status": ["medicine cat", "elder"],
       "skill": ["LORE,1"]
     }

--- a/resources/dicts/events/misc_events/mountainous.json
+++ b/resources/dicts/events/misc_events/mountainous.json
@@ -20,7 +20,7 @@
     "event_text": "As a storm rages across the mountain outside, m_c is tucked up in the medicine cat den, {PRONOUN/m_c/poss} sleep anything but restful. {PRONOUN/m_c/subject/CAP} {VERB/m_c/keep/keeps} seeing flashes of prophecy_list_sight. {PRONOUN/m_c/subject/CAP} {VERB/m_c/wake/wakes} with a shiver, wondering what {PRONOUN/m_c/poss} dreams mean for the Clan.",
     "m_c": {
       "status": ["medicine cat", "medicine cat apprentice"],
-      "skill": ["PROPHET,1"]
+      "skill": ["PROPHET,2", "PROPHET,3"]
     }
   },
   {
@@ -32,7 +32,7 @@
     "event_text": "The things {PRONOUN/m_c/subject} saw today, omen_list_sight... m_c sits on an isolated mountain ledge, considering what the omens foretell.",
     "m_c": {
       "status": ["medicine cat", "medicine cat apprentice"],
-      "skill": ["OMEN,1"]
+      "skill": ["OMEN,2", "OMEN,3"]
     }
   },
   {

--- a/resources/dicts/events/misc_events/mountainous.json
+++ b/resources/dicts/events/misc_events/mountainous.json
@@ -1,116 +1,51 @@
 [
-    {
-        "event_id": "mtn_misc_",
-        "biome": [
-            "mountainous"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "war"
-        ],
-        "weight": 20,
-        "event_text": "The apprentices of the Clan are taking special strength training to learn how to weaponize stones and boulders in the mountain landscape.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        }
-    },
-    {
-        "event_id": "mtn_misc_",
-        "biome": [
-            "mountainous"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "As a storm rages across the mountain outside, m_c is tucked up in the medicine cat den, {PRONOUN/m_c/poss} sleep anything but restful. {PRONOUN/m_c/subject/CAP} {VERB/m_c/keep/keeps} seeing flashes of prophecy_list_sight. {PRONOUN/m_c/subject/CAP} {VERB/m_c/wake/wakes} with a shiver, wondering what {PRONOUN/m_c/poss} dreams mean for the Clan.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ],
-            "skill": [
-                "PROPHET,1"
-            ]
-        }
-    },
-    {
-        "event_id": "mtn_misc_",
-        "biome": [
-            "mountainous"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "The things {PRONOUN/m_c/subject} saw today, omen_list_sight... m_c sits on an isolated mountain ledge, considering what the omens foretell.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ],
-            "skill": [
-                "OMEN,1"
-            ]
-        }
-    },
-    {
-        "event_id": "mtn_misc_",
-        "biome": [
-            "mountainous"
-        ],
-        "camp": [
-            "camp2"
-        ],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [
-            "clan_kits"
-        ],
-        "weight": 20,
-        "event_text": "Through the long, cold night, m_c brings the young cats of the Clan with {PRONOUN/m_c/object} down the tunnels. {PRONOUN/m_c/poss} words paint an enchanting picture of the ancestors of c_n as {PRONOUN/m_c/subject} {VERB/m_c/point/points} out the red pawprints of long dead heroes and villains, telling the Clan's triumphs and failures.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ],
-            "skill": [
-                "LORE,1"
-            ]
-        }
+  {
+    "event_id": "mtn_misc_war_any_apps1",
+    "biome": ["mountainous"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["war", "clan_apps"],
+    "weight": 15,
+    "event_text": "The apprentices of the Clan are taking special strength training to learn how to weaponize stones and boulders in the mountain landscape.",
+    "m_c": {
+      "status": ["apprentice"]
     }
+  },
+  {
+    "event_id": "mtn_misc_any_prophecymedcatprophet1",
+    "biome": ["mountainous"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "As a storm rages across the mountain outside, m_c is tucked up in the medicine cat den, {PRONOUN/m_c/poss} sleep anything but restful. {PRONOUN/m_c/subject/CAP} {VERB/m_c/keep/keeps} seeing flashes of prophecy_list_sight. {PRONOUN/m_c/subject/CAP} {VERB/m_c/wake/wakes} with a shiver, wondering what {PRONOUN/m_c/poss} dreams mean for the Clan.",
+    "m_c": {
+      "status": ["medicine cat", "medicine cat apprentice"],
+      "skill": ["PROPHET,1"]
+    }
+  },
+  {
+    "event_id": "mtn_misc_any_omenmedcatomen1",
+    "biome": ["mountainous"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "The things {PRONOUN/m_c/subject} saw today, omen_list_sight... m_c sits on an isolated mountain ledge, considering what the omens foretell.",
+    "m_c": {
+      "status": ["medicine cat", "medicine cat apprentice"],
+      "skill": ["OMEN,1"]
+    }
+  },
+  {
+    "event_id": "mtn_misc_camptwo_leafbaremultilore1",
+    "biome": ["mountainous"],
+    "camp": ["camp2"],
+    "season": ["leaf-bare"],
+    "tags": ["clan_kits"],
+    "weight": 10,
+    "event_text": "Through the long, cold night, m_c brings the young cats of the Clan with {PRONOUN/m_c/object} down the tunnels. {PRONOUN/m_c/poss} words paint an enchanting picture of the ancestors of c_n as {PRONOUN/m_c/subject} {VERB/m_c/point/points} out the red pawprints of long dead heroes and villains, telling the Clan's triumphs and failures.",
+    "m_c": {
+      "status": ["medicine cat", "elder"],
+      "skill": ["LORE,1"]
+    }
+  }
 ]

--- a/resources/dicts/events/misc_events/plains.json
+++ b/resources/dicts/events/misc_events/plains.json
@@ -1,38 +1,42 @@
 [
   {
-    "event_id": "pln_misc_war_any_apps1",
+    "event_id": "pln_misc_war_anyapps1",
     "biome": ["plains"],
     "camp": ["any"],
     "season": ["any"],
-    "tags": ["war", "clan_apps"],
+    "sub_type": ["war"],
+    "tags": ["clan_apps"],
     "weight": 15,
     "event_text": "The apprentices of the Clan are taking special training to learn how to survive in underground tunnels long-term, in the case of a siege conducted by o_c.",
     "m_c": {
+      "age": ["any"],
       "status": ["apprentice"]
     }
   },
   {
-    "event_id": "pln_misc_any_prophecymedcatprophet1",
+    "event_id": "pln_misc_anyprophecymedcatprophet1",
     "biome": ["plains"],
     "camp": ["any"],
     "season": ["any"],
     "weight": 10,
     "event_text": "As the wind howls on the plains outside, m_c is tucked up in the medicine cat den, {PRONOUN/m_c/poss} sleep anything but restful. {PRONOUN/m_c/subject/CAP} {VERB/m_c/keep/keeps} seeing flashes of prophecy_list_sight. {PRONOUN/m_c/subject/CAP} {VERB/m_c/wake/wakes} with a shiver, wondering what {PRONOUN/m_c/poss} dreams mean for the Clan.",
     "m_c": {
+      "age": ["any"],
       "status": ["medicine cat", "medicine cat apprentice"],
-      "skill": ["PROPHET,2", "PROPHET,3"]
+      "skill": ["PROPHET,2"]
     }
   },
   {
-    "event_id": "pln_misc_any_omenmedcatomen1",
+    "event_id": "pln_misc_anyomenmedcatomen1",
     "biome": ["plains"],
     "camp": ["any"],
     "season": ["any"],
     "weight": 10,
     "event_text": "The things {PRONOUN/m_c/subject} saw today, omen_list_sight... m_c isolates {PRONOUN/m_c/self} in the shifting long grass, considering what the omens foretell.",
     "m_c": {
+      "age": ["any"],
       "status": ["medicine cat", "medicine cat apprentice"],
-      "skill": ["OMEN,2", "OMEN,3"]
+      "skill": ["OMEN,2"]
     }
   }
 ]

--- a/resources/dicts/events/misc_events/plains.json
+++ b/resources/dicts/events/misc_events/plains.json
@@ -1,84 +1,38 @@
 [
-    {
-        "event_id": "pln_misc_",
-        "biome": [
-            "plains"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "As the wind howls on the plains outside, m_c is tucked up in the medicine cat den, {PRONOUN/m_c/poss} sleep anything but restful. {PRONOUN/m_c/subject/CAP} {VERB/m_c/keep/keeps} seeing flashes of prophecy_list_sight. {PRONOUN/m_c/subject/CAP} {VERB/m_c/wake/wakes} with a shiver, wondering what {PRONOUN/m_c/poss} dreams mean for the Clan.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ],
-            "skill": [
-                "PROPHET,3"
-            ]
-        }
-    },
-    {
-        "event_id": "pln_misc_",
-        "biome": [
-            "plains"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "The things {PRONOUN/m_c/subject} saw today, omen_list_sight... m_c isolates {PRONOUN/m_c/self} in the shifting long grass, considering what the omens foretell.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "medicine cat"
-            ],
-            "skill": [
-                "OMEN,3"
-            ]
-        }
-    },
-    {
-        "event_id": "pln_misc_",
-        "biome": [
-            "plains"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "war"
-        ],
-        "weight": 20,
-        "event_text": "The apprentices of the Clan are taking special training to learn how to survive in underground tunnels long-term, in the case of a siege conducted by o_c.",
-        "m_c": {
-            "age": [
-                "adolescent"
-            ],
-            "status": [
-                "apprentice"
-            ]
-        }
-    }]
+  {
+    "event_id": "pln_misc_war_any_apps1",
+    "biome": ["plains"],
+    "camp": ["any"],
+    "season": ["any"],
+    "tags": ["war", "clan_apps"],
+    "weight": 15,
+    "event_text": "The apprentices of the Clan are taking special training to learn how to survive in underground tunnels long-term, in the case of a siege conducted by o_c.",
+    "m_c": {
+      "status": ["apprentice"]
+    }
+  },
+  {
+    "event_id": "pln_misc_any_prophecymedcatprophet1",
+    "biome": ["plains"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "As the wind howls on the plains outside, m_c is tucked up in the medicine cat den, {PRONOUN/m_c/poss} sleep anything but restful. {PRONOUN/m_c/subject/CAP} {VERB/m_c/keep/keeps} seeing flashes of prophecy_list_sight. {PRONOUN/m_c/subject/CAP} {VERB/m_c/wake/wakes} with a shiver, wondering what {PRONOUN/m_c/poss} dreams mean for the Clan.",
+    "m_c": {
+      "status": ["medicine cat", "medicine cat apprentice"],
+      "skill": ["PROPHET,2", "PROPHET,3"]
+    }
+  },
+  {
+    "event_id": "pln_misc_any_omenmedcatomen1",
+    "biome": ["plains"],
+    "camp": ["any"],
+    "season": ["any"],
+    "weight": 10,
+    "event_text": "The things {PRONOUN/m_c/subject} saw today, omen_list_sight... m_c isolates {PRONOUN/m_c/self} in the shifting long grass, considering what the omens foretell.",
+    "m_c": {
+      "status": ["medicine cat", "medicine cat apprentice"],
+      "skill": ["OMEN,2", "OMEN,3"]
+    }
+  }
+]

--- a/resources/dicts/events/new_cat/general.json
+++ b/resources/dicts/events/new_cat/general.json
@@ -1,798 +1,537 @@
-[    
+[
     {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "adoption",
-            "m_c"
-        ],
-        "weight": 20,
-        "event_text": "m_c finds an abandoned kit and names {PRONOUN/n_c/object} n_c.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "new_cat": [
-            [
-                "new_name",
-                "loner"
-            ]
-        ],
-        "outsider": {
-            "current_rep": [],
-            "changed": 1
-        }
-    },
-    {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "adoption",
-            "m_c"
-        ],
-        "weight": 20,
-        "event_text": "m_c finds an abandoned kit and names {PRONOUN/n_c/object} n_c.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "new_cat": [
-            [
-                "new_name",
-                "kittypet"
-            ]
-        ],
-        "outsider": {
-            "current_rep": [],
-            "changed": 1
-        }
-    },
-    {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "A loner brings their kit named n_c_pre to the Clan, stating they no longer can care for {PRONOUN/n_c/object}.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "new_cat": [
-            [
-                "new_name",
-                "loner"
-            ]
-        ],
-        "outsider": {
-            "current_rep": [],
-            "changed": 1
-        }
-    },
-    {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "A kittypet brings their kit named n_c_pre to the Clan, stating they no longer can care for {PRONOUN/n_c/object}.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "new_cat": [
-            [
-                "new_name",
-                "kittypet"
-            ]
-        ],
-        "outsider": {
-            "current_rep": [],
-            "changed": 1
-        }
-    },
-    {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "A rogue brings their kit named n_c_pre to the Clan, stating they no longer can care for {PRONOUN/n_c/object}.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "new_cat": [
-            [
-                "new_name",
-                "loner"
-            ]
-        ],
-        "outsider": {
-            "current_rep": [],
-            "changed": 1
-        }
-    },
-    {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "m_c"
-        ],
-        "weight": 20,
-        "event_text": "m_c finds a loner named n_c_pre, who joins the Clan. The loner decides to keep {PRONOUN/n_c/poss} old name.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "new_cat": [
-            [
-                "loner"
-            ]
-        ],
-        "outsider": {
-            "current_rep": [],
-            "changed": 1
-        }
-    },
-    {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "m_c"
-        ],
-        "weight": 20,
-        "event_text": "m_c finds a loner named n_c_pre, who joins the Clan. The loner decides to take on a more Clan-like name, and is now called n_c.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "new_cat": [
-            [
-                "new_name",
-                "loner"
-            ]
-        ],
-        "outsider": {
-            "current_rep": [],
-            "changed": 1
-        }
-    },
-    {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "A loner waits on the border for a patrol, asking to join the Clan. The loner decides to keep {PRONOUN/n_c/poss} old name, n_c.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "new_cat": [
-            [
-                "loner"
-            ]
-        ],
-        "outsider": {
-            "current_rep": [],
-            "changed": 1
-        }
-    },
-    {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "A loner waits on the border for a patrol, asking to join the Clan. The loner decides to take on a more Clan-like name, and is now called n_c.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "new_cat": [
-            [
-                "new_name",
-                "loner"
-            ]
-        ],
-        "outsider": {
-            "current_rep": [],
-            "changed": 1
-        }
-    },
-    {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "m_c"
-        ],
-        "weight": 20,
-        "event_text": "m_c finds a kittypet named n_c_pre, who joins the Clan. The kittypet decides to keep {PRONOUN/n_c/poss} old name.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "new_cat": [
-            [
-                "kittypet"
-            ]
-        ],
-        "outsider": {
-            "current_rep": [],
-            "changed": 1
-        }
-    },
-    {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "m_c"
-        ],
-        "weight": 20,
-        "event_text": "m_c finds a kittypet named n_c_pre, who joins the Clan. The kittypet decides to take on a more Clan-like name, and is now called n_c.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "new_cat": [
-            [
-                "new_name",
-                "kittypet"
-            ]
-        ],
-        "outsider": {
-            "current_rep": [],
-            "changed": 1
-        }
-    },
-    {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "A kittypet waits on the border for a patrol, asking to join the Clan. The kittypet decides to keep {PRONOUN/n_c/poss} old name, n_c.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "new_cat": [
-            [
-                "kittypet"
-            ]
-        ],
-        "outsider": {
-            "current_rep": [],
-            "changed": 1
-        }
-    },
-    {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "A kittypet waits on the border for a patrol, asking to join the Clan. The kittypet decides to take on a more Clan-like name, and is now called n_c.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "new_cat": [
-            [
-                "new_name",
-                "kittypet"
-            ]
-        ],
-        "outsider": {
-            "current_rep": [
-                "welcoming"
-            ],
-            "changed": 1
-        }
-    },
-    {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "m_c"
-        ],
-        "weight": 20,
-        "event_text": "m_c finds a rogue named n_c_pre, who joins the Clan. The rogue decides to keep {PRONOUN/n_c/poss} old name.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "new_cat": [
-            [
-                "loner"
-            ]
-        ],
-        "outsider": {
-            "current_rep": [],
-            "changed": 1
-        }
-    },
-    {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "m_c"
-        ],
-        "weight": 20,
-        "event_text": "m_c finds a rogue named n_c_pre, who joins the Clan. The rogue decides to take on a more Clan-like name, and is now called n_c.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "new_cat": [
-            [
-                "new_name",
-                "loner"
-            ]
-        ],
-        "outsider": {
-            "current_rep": [],
-            "changed": 1
-        }
-    },
-    {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "A rogue waits on the border for a patrol, asking to join the Clan. The rogue decides to keep {PRONOUN/n_c/poss} old name, n_c.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "new_cat": [
-            [
-                "loner"
-            ]
-        ],
-        "outsider": {
-            "current_rep": [],
-            "changed": 1
-        }
-    },
-    {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "A rogue waits on the border for a patrol, asking to join the Clan. The rogue decides to take on a more Clan-like name, and is now called n_c.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "new_cat": [
-            [
-                "new_name",
-                "loner"
-            ]
-        ],
-        "outsider": {
-            "current_rep": [],
-            "changed": 1
-        }
-    },
-    {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "m_c"
-        ],
-        "weight": 20,
-        "event_text": "m_c finds a warrior from o_c named n_c, who asks to join the Clan.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "new_cat": [
-            [
-                "status:{warrior}"
-            ]
-        ],
-        "outsider": {
-            "current_rep": [
-                "neutral"
-            ],
-            "changed": 1
-        }
-    },
-    {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "injured",
-            "major_injury"
-        ],
-        "weight": 20,
-        "event_text": "An injured warrior from o_c asks to join, in exchange for healing.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "new_cat": [
-            [
-                "status:{warrior}"
-            ]
-        ],
-        "outsider": {
-            "current_rep": [
-                "neutral"
-            ],
-            "changed": 1
-        }
-    },
-    {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "adoption",
-            "m_c"
-        ],
-        "weight": 20,
-        "event_text": "A o_c queen decides to leave their litter with you. m_c takes them as {PRONOUN/m_c/poss} own.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "new_cat": [
-            [
-                "litter"
-            ]
-        ],
-        "outsider": {
-            "current_rep": [],
-            "changed": 1
-        }
-    },
-    {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "adoption",
-            "m_c"
-        ],
-        "weight": 20,
-        "event_text": "m_c finds an abandoned litter, and decides to adopt them as {PRONOUN/m_c/poss} own.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "new_cat": [
-            [
-                "new_name",
-                "loner",
-                "litter"
-            ]
-        ],
-        "outsider": {
-            "current_rep": [],
-            "changed": 1
-        }
-    },
-    {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "adoption",
-            "m_c"
-        ],
+        "event_id": "gen_new_cat_adoption_anylonerlitter1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "tags": ["adoption"],
         "weight": 20,
         "event_text": "A loner leaves their litter to the Clan. m_c decides to adopt them as {PRONOUN/m_c/poss} own.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": ["young adult", "adult", "senior adult", "senior"]
         },
         "new_cat": [
+            ["age:has_kits", "meeting", "loner", "can_birth"],
             [
                 "new_name",
-                "loner",
+                "parent:0",
+                "backstory:abandoned2, outsider1",
                 "litter"
             ]
         ],
         "outsider": {
-            "current_rep": [],
-            "changed": 1
+            "current_rep": ["any"]
         }
     },
     {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
+        "event_id": "gen_new_cat_adoption_anyroguelitter1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "tags":["adoption"],
+        "weight": 10,
+        "event_text": "A rogue leaves their litter to the Clan. m_c decides to adopt them as {PRONOUN/m_c/poss} own.",
+        "m_c": {
+            "age": ["young adult", "adult", "senior adult", "senior"]
+        },
+        "new_cat": [
+            ["age:has_kits", "meeting", "rogue", "can_birth"],
+            [
+                "new_name",
+                "parent:0",
+                "backstory: abandoned2, outsider1",
+                "status: litter" 
+            ]
         ],
-        "season": [
-            "any"
+        "outsider": {
+            "current_rep": ["any"]
+        }
+    },
+    {
+        "event_id": "gen_new_cat_adoption_anywelcomingotherclanlitter1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "tags": ["adoption"],
+        "weight": 10,
+        "event_text": "A o_c queen decides to leave their litter with you. m_c takes them as {PRONOUN/m_c/poss} own.",
+        "m_c": {
+            "age": ["young adult", "adult", "senior adult", "senior"]
+        },
+        "new_cat": [
+            ["age:has_kits", "meeting", "clancat", "can_birth"],
+            [
+                "new_name",
+                "parent:0",
+                "backstory:abandoned2, outsider1",
+                "litter"
+            ]
         ],
-        "tags": [
-            "adoption",
-            "m_c"
-        ],
-        "weight": 20,
+        "outsider": {
+            "current_rep": ["welcoming"]
+        }
+    },
+    {
+        "event_id": "gen_new_cat_adoption_anymultirepkittypetlitter1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "tags": ["adoption"],
+        "weight": 5,
         "event_text": "A kittypet leaves their litter to the Clan. m_c decides to adopt them as {PRONOUN/m_c/poss} own.",
         "m_c": {
-            "age": [],
-            "status": []
+            "age": ["young adult", "adult", "senior adult", "senior"]
         },
+        "new_cat": [
+            ["age:has_kits", "meeting", "kittypet", "can_birth"],
+            [
+                "new_name",
+                "parent:0",
+                "backstory:abandoned2, outsider1",
+                "litter"
+            ]
+        ],
+        "outsider": {
+            "current_rep": ["neutral","welcoming"]
+        }
+    },
+    {
+        "event_id": "gen_new_cat_adoption_anylitter1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "tags": ["adoption"],
+        "weight": 20,
+        "event_text": "m_c finds an abandoned litter, and decides to adopt them as {PRONOUN/m_c/poss} own.",
+        "m_c": {
+            "age": ["young adult", "adult", "senior adult", "senior"]
+        },
+        "new_cat": [
+            [
+                "new_name",
+                "backstory:abandoned2, outsider1",
+                "litter"
+            ]
+        ]
+    },
+    {
+        "event_id": "gen_new_cat_anykit1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 20,
+        "event_text": "m_c finds an abandoned kit and names {PRONOUN/n_c/object} n_c.",
+        "new_cat": [
+            [
+                "new_name",
+                "backstory: abandoned1, abandoned2, orphaned3, orphaned4, outsider1",
+                "status: kitten"
+            ]
+        ]
+    },
+    {
+        "event_id": "gen_new_cat_anylonerkit1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 20,
+        "event_text": "A loner brings their kit named n_c_pre to the Clan, stating they no longer can care for {PRONOUN/n_c/object}.",
+        "new_cat": [
+            ["age:has_kits", "meeting", "loner", "can_birth"],
+            [
+                "new_name",
+                "parent:0",
+                "backstory: abandoned2, outsider1",
+                "status: kitten" 
+            ]
+        ]
+    },
+    {
+        "event_id": "gen_new_cat_anykittypetkit1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 10,
+        "event_text": "A kittypet brings their kit named n_c_pre to the Clan, stating they no longer can care for {PRONOUN/n_c/object}.",
+        "new_cat": [
+            ["age:has_kits", "meeting", "kittypet", "can_birth"],
+            [
+                "new_name",
+                "parent:0",
+                "backstory: abandoned2, outsider1",
+                "status: kitten" 
+            ]
+        ]
+    },
+    {
+        "event_id": "gen_new_cat_anyroguekit1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 5,
+        "event_text": "A rogue brings their kit named n_c_pre to the Clan, stating they no longer can care for {PRONOUN/n_c/object}.",
+        "new_cat": [
+            ["age:has_kits", "meeting", "rogue", "can_birth"],
+            [
+                "new_name",
+                "parent:0",
+                "backstory: abandoned2, outsider1",
+                "status: kitten" 
+            ]
+        ]
+    },  
+    {
+        "event_id": "gen_new_cat_anypolymate1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "tags":["romance"],
+        "weight": 5,
+        "event_text": "m_c and r_c, in the early hours of the day, informed whoever else was awake that they had to handle something and ventured out of camp. Hours later, m_c, r_c, and another cat confidently strode into camp, tails entwined with each other. m_c introduced n_c:0 to the Clan, stating that {PRONOUN/n_c/subject} {VERB/n_c/are/is} staying.",
+        "m_c": {
+            "age": ["young adult", "adult", "senior adult", "senior"],
+            "relationship_status": ["mates"]
+          },
+          "r_c": {
+            "age": ["young adult", "adult", "senior adult", "senior"],
+            "relationship_status": ["mates"]
+        },
+        "new_cat": [
+            [
+                "old_name",
+                "loner",
+                "status: warrior",
+                "mate:m_c,r_c" 
+            ]
+        ],
+        "relationships": [
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["n_c:0"],
+            "mutual": true,
+            "values": ["romantice", "trust"],
+            "amount": 55
+          },
+          {
+            "cats_from": ["m_c"],
+            "cats_to": ["n_c:0"],
+            "mutual": true,
+            "values": ["comfort"],
+            "amount": 25
+          },
+          {
+            "cats_from": ["r_c"],
+            "cats_to": ["n_c:0"],
+            "mutual": true,
+            "values": ["romantice", "trust"],
+            "amount": 55
+          },
+          {
+            "cats_from": ["r_c"],
+            "cats_to": ["n_c:0"],
+            "mutual": true,
+            "values": ["comfort"],
+            "amount": 25
+          }
+        ]
+    },
+    {
+        "event_id": "gen_new_cat_anyloner1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 15,
+        "event_text": "m_c finds a loner named n_c_pre, who joins the Clan. The loner decides to keep {PRONOUN/n_c/poss} old name.",
+        "new_cat": [
+            [
+                "old_name",
+                "loner",
+                "status: warrior" 
+            ]
+        ]
+    },
+    {
+        "event_id": "gen_new_cat_anyloner2",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 20,
+        "event_text": "A loner waits on the border for a patrol, asking to join the Clan. The loner decides to take on a more Clan-like name, and is now called n_c.",
+        "new_cat": [
+            [
+                "new_name",
+                "loner",
+                "status: warrior"
+            ]
+        ]
+    },
+    {
+        "event_id": "gen_new_cat_anyloner3",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 20,
+        "event_text": "A loner waits on the border for a patrol, asking to join the Clan. The loner decides to keep {PRONOUN/n_c/poss} old name, n_c.",
+        "new_cat": [
+            [
+                "old_name",
+                "loner",
+                "status: warrior"
+            ]
+        ]
+    },
+    {
+        "event_id": "gen_new_cat_anyloner4",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 20,
+        "event_text": "m_c finds a loner named n_c_pre, who joins the Clan. The loner decides to take on a more Clan-like name, and is now called n_c.",
+        "new_cat": [
+            [
+                "new_name",
+                "loner",
+                "status: warrior"
+            ]
+        ]
+    },
+    {
+        "event_id": "gen_new_cat_hostile_anyloner1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 15,
+        "event_text": "While the Clan has no love for outsiders, sometimes new blood is needed. A patrol heads out and finds a wandering cat to bring into the Clan. The new cat, n_c_pre takes on a more Clan-like name.",
+        "new_cat": [
+            [
+                "new_name",
+                "loner",
+                "status: warrior" 
+            ]
+        ],
+        "outsider": {
+            "current_rep": ["hostile"]
+        }
+    },
+    {
+        "event_id": "gen_new_cat_anykittypet1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 20,
+        "event_text": "m_c finds a kittypet named n_c_pre, who joins the Clan. The kittypet decides to keep {PRONOUN/n_c/poss} old name.",
+        "new_cat": [
+            [
+                "old_name",
+                "kittypet",
+                "status: warrior" 
+            ]
+        ]
+    },
+    {
+        "event_id": "gen_new_cat_anykittypet2",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 20,
+        "event_text": "m_c finds a kittypet named n_c_pre, who joins the Clan. The kittypet decides to take on a more Clan-like name, and is now called n_c.",
         "new_cat": [
             [
                 "new_name",
                 "kittypet",
-                "litter"
+                "status: warrior" 
             ]
-        ],
-        "outsider": {
-            "current_rep": [],
-            "changed": 1
-        }
+        ]
     },
     {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "adoption",
-            "m_c"
-        ],
+        "event_id": "gen_new_cat_anykittypet2",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
         "weight": 20,
-        "event_text": "A rogue leaves their litter to the Clan. m_c decides to adopt them as {PRONOUN/m_c/poss} own.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
+        "event_text": "m_c finds a kittypet named n_c_pre, who joins the Clan. The kittypet decides to take on a more Clan-like name, and is now called n_c.",
         "new_cat": [
             [
                 "new_name",
-                "loner",
-                "litter"
+                "kittypet",
+                "status: warrior" 
             ]
-        ],
-        "outsider": {
-            "current_rep": [],
-            "changed": 1
-        }
+        ]
     },
     {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
+        "event_id": "gen_new_cat_anykittypet3",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
         "weight": 20,
-        "event_text": "While the Clan has no love for outsiders, sometimes new blood is needed. A patrol heads out and finds a wandering cat to bring into the Clan. The new cat, n_c_pre takes on a more Clan-like name.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
+        "event_text": "A kittypet waits on the border for a patrol, asking to join the Clan. The kittypet decides to keep {PRONOUN/n_c/poss} old name, n_c.",
+        "new_cat": [
+            [
+                "old_name",
+                "kittypet",
+                "status: warrior" 
+            ]
+        ]
+    },
+    {
+        "event_id": "gen_new_cat_anykittypet3",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 20,
+        "event_text": "A kittypet waits on the border for a patrol, asking to join the Clan. The kittypet decides to take on a more Clan-like name, and is now called n_c.",
         "new_cat": [
             [
                 "new_name",
-                "loner"
+                "kittypet",
+                "status: warrior" 
             ]
-        ],
-        "outsider": {
-            "current_rep": [],
-            "changed": 1
-        }
+        ]
+    },
+
+    {
+        "event_id": "gen_new_cat_anyrogue1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 20,
+        "event_text": "m_c finds a rogue named n_c_pre, who joins the Clan. The rogue decides to keep {PRONOUN/n_c/poss} old name.",
+        "new_cat": [
+            [
+                "old_name",
+                "rogue",
+                "status: warrior" 
+            ]
+        ]
     },
     {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "war"
-        ],
+        "event_id": "gen_new_cat_anyrogue2",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
         "weight": 20,
+        "event_text": "m_c finds a rogue named n_c_pre, who joins the Clan. The rogue decides to take on a more Clan-like name, and is now called n_c.",
+        "new_cat": [
+            [
+                "new_name",
+                "rogue",
+                "status: warrior" 
+            ]
+        ]
+    },
+    {
+        "event_id": "gen_new_cat_anyrogue3",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 20,
+        "event_text": "A rogue waits on the border for a patrol, asking to join the Clan. The rogue decides to keep {PRONOUN/n_c/poss} old name, n_c.",
+        "new_cat": [
+            [
+                "old_name",
+                "rogue",
+                "status: warrior" 
+            ]
+        ]
+    },
+    {
+        "event_id": "gen_new_cat_anyrogue4",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 20,
+        "event_text": "A rogue waits on the border for a patrol, asking to join the Clan. The rogue decides to keep {PRONOUN/n_c/poss} old name, n_c.",
+        "new_cat": [
+            [
+                "new_name",
+                "rogue",
+                "status: warrior" 
+            ]
+        ]
+    },
+
+    {
+        "event_id": "gen_new_cat_anyotherclancat1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 20,
+        "event_text": "m_c finds a warrior from o_c named n_c, who asks to join the Clan.",
+        "new_cat": [
+            [
+                "old_name",
+                "clancat",
+                "status:{warrior}"
+            ]
+        ]
+    },
+    {
+        "event_id": "gen_new_cat_anyotherclancat2",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "weight": 10,
+        "event_text": "An injured warrior from o_c asks to join, in exchange for healing.",
+        "new_cat": [
+            [
+                "old_name",
+                "clancat",
+                "status:{warrior}"
+            ]
+        ],
+        "injury": [
+           {
+            "cats": ["n_c:0"],
+            "injuries": ["battle_injury", "big_bite_injury"]
+           }
+        ]
+    },
+    {
+        "event_id": "gen_new_cat_war_any1",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "tags": ["war"],
+        "weight": 15,
         "event_text": "A member of o_c defects in the war and chooses to join c_n. {PRONOUN/n_c/subject/CAP} {VERB/n_c/decide/decides} to keep {PRONOUN/n_c/poss} name.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
         "new_cat": [
-            [
-                "old_name"
-            ]
-        ],
-        "outsider": {
-            "current_rep": [],
-            "changed": 1
-        }
+          [
+            "old_name", 
+            "backstory:ostracized_warrior,disgraced1,disgraced2,otherclan", 
+            "status:warrior"
+          ]
+        ]
     },
     {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "A member of o_c defects from their birth Clan and chooses to join c_n. {PRONOUN/n_c/subject/CAP} {VERB/n_c/decide/decides} to keep {PRONOUN/n_c/poss} name.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
-        "new_cat": [
-            [
-                "old_name"
-            ]
-        ],
-        "outsider": {
-            "current_rep": [],
-            "changed": 1
-        }
-    },
-    {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "war"
-        ],
-        "weight": 20,
+        "event_id": "gen_new_cat_war_any2",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "tags": ["war"],
+        "weight": 10,
         "event_text": "n_c, the deputy of o_c, has defected to c_n in the war. {PRONOUN/n_c/subject/CAP} {VERB/n_c/decide/decides} to keep {PRONOUN/n_c/poss} name.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
         "new_cat": [
-            [
-                "old_name"
-            ]
-        ],
-        "outsider": {
-            "current_rep": [],
-            "changed": 1
-        }
+          [
+            "old_name", 
+            "backstory:ostracized_warrior,disgraced1,disgraced2,disgraced3,otherclan", 
+            "status:warrior"
+          ]
+        ]
     },
     {
-        "event_id": "gen_new_cat_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "war",
-            "medicine_cat"
-        ],
-        "weight": 20,
+        "event_id": "gen_new_cat_war_any2",
+        "biome": ["any"],
+        "camp": ["any"],
+        "season": ["any"],
+        "tags": ["war"],
+        "weight": 15,
         "event_text": "n_c, the medicine cat of o_c, has defected to c_n in the war. {PRONOUN/n_c/subject/CAP} {VERB/n_c/decide/decides} to keep {PRONOUN/n_c/poss} name.",
-        "m_c": {
-            "age": [],
-            "status": []
-        },
         "new_cat": [
-            [
-                "old_name"
-            ]
-        ],
-        "outsider": {
-            "current_rep": [],
-            "changed": 1
-        }
+          [
+            "old_name", 
+            "backstory:medicine_cat", 
+            "status:medicine_cat"
+          ]
+        ]
     }
 ]

--- a/resources/dicts/events/new_cat/general.json
+++ b/resources/dicts/events/new_cat/general.json
@@ -8,7 +8,8 @@
         "weight": 20,
         "event_text": "A loner leaves their litter to the Clan. m_c decides to adopt them as {PRONOUN/m_c/poss} own.",
         "m_c": {
-            "age": ["young adult", "adult", "senior adult", "senior"]
+            "age": ["young adult", "adult", "senior adult", "senior"],
+            "status": ["any"]
         },
         "new_cat": [
             ["age:has_kits", "meeting", "loner", "can_birth"],
@@ -32,7 +33,8 @@
         "weight": 10,
         "event_text": "A rogue leaves their litter to the Clan. m_c decides to adopt them as {PRONOUN/m_c/poss} own.",
         "m_c": {
-            "age": ["young adult", "adult", "senior adult", "senior"]
+            "age": ["young adult", "adult", "senior adult", "senior"],
+            "status": ["any"]
         },
         "new_cat": [
             ["age:has_kits", "meeting", "rogue", "can_birth"],
@@ -56,7 +58,8 @@
         "weight": 10,
         "event_text": "A o_c queen decides to leave their litter with you. m_c takes them as {PRONOUN/m_c/poss} own.",
         "m_c": {
-            "age": ["young adult", "adult", "senior adult", "senior"]
+            "age": ["young adult", "adult", "senior adult", "senior"],
+            "status": ["any"]
         },
         "new_cat": [
             ["age:has_kits", "meeting", "clancat", "can_birth"],
@@ -80,7 +83,8 @@
         "weight": 5,
         "event_text": "A kittypet leaves their litter to the Clan. m_c decides to adopt them as {PRONOUN/m_c/poss} own.",
         "m_c": {
-            "age": ["young adult", "adult", "senior adult", "senior"]
+            "age": ["young adult", "adult", "senior adult", "senior"],
+            "status": ["any"]
         },
         "new_cat": [
             ["age:has_kits", "meeting", "kittypet", "can_birth"],
@@ -104,7 +108,8 @@
         "weight": 20,
         "event_text": "m_c finds an abandoned litter, and decides to adopt them as {PRONOUN/m_c/poss} own.",
         "m_c": {
-            "age": ["young adult", "adult", "senior adult", "senior"]
+            "age": ["young adult", "adult", "senior adult", "senior"],
+            "status": ["any"]
         },
         "new_cat": [
             [
@@ -121,6 +126,10 @@
         "season": ["any"],
         "weight": 20,
         "event_text": "m_c finds an abandoned kit and names {PRONOUN/n_c/object} n_c.",
+        "m_c": {
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "status": ["any"]
+        },
         "new_cat": [
             [
                 "new_name",
@@ -190,10 +199,12 @@
         "event_text": "m_c and r_c, in the early hours of the day, informed whoever else was awake that they had to handle something and ventured out of camp. Hours later, m_c, r_c, and another cat confidently strode into camp, tails entwined with each other. m_c introduced n_c:0 to the Clan, stating that {PRONOUN/n_c/subject} {VERB/n_c/are/is} staying.",
         "m_c": {
             "age": ["young adult", "adult", "senior adult", "senior"],
+            "status": ["any"],
             "relationship_status": ["mates"]
           },
           "r_c": {
             "age": ["young adult", "adult", "senior adult", "senior"],
+            "status": ["any"],
             "relationship_status": ["mates"]
         },
         "new_cat": [
@@ -242,6 +253,10 @@
         "season": ["any"],
         "weight": 15,
         "event_text": "m_c finds a loner named n_c_pre, who joins the Clan. The loner decides to keep {PRONOUN/n_c/poss} old name.",
+        "m_c": {
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "status": ["any"]
+        },
         "new_cat": [
             [
                 "old_name",
@@ -287,6 +302,10 @@
         "season": ["any"],
         "weight": 20,
         "event_text": "m_c finds a loner named n_c_pre, who joins the Clan. The loner decides to take on a more Clan-like name, and is now called n_c.",
+        "m_c": {
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "status": ["any"]
+        },
         "new_cat": [
             [
                 "new_name",
@@ -320,6 +339,10 @@
         "season": ["any"],
         "weight": 20,
         "event_text": "m_c finds a kittypet named n_c_pre, who joins the Clan. The kittypet decides to keep {PRONOUN/n_c/poss} old name.",
+        "m_c": {
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "status": ["any"]
+        },
         "new_cat": [
             [
                 "old_name",
@@ -335,21 +358,10 @@
         "season": ["any"],
         "weight": 20,
         "event_text": "m_c finds a kittypet named n_c_pre, who joins the Clan. The kittypet decides to take on a more Clan-like name, and is now called n_c.",
-        "new_cat": [
-            [
-                "new_name",
-                "kittypet",
-                "status: warrior" 
-            ]
-        ]
-    },
-    {
-        "event_id": "gen_new_cat_anykittypet2",
-        "biome": ["any"],
-        "camp": ["any"],
-        "season": ["any"],
-        "weight": 20,
-        "event_text": "m_c finds a kittypet named n_c_pre, who joins the Clan. The kittypet decides to take on a more Clan-like name, and is now called n_c.",
+        "m_c": {
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "status": ["any"]
+        },
         "new_cat": [
             [
                 "new_name",
@@ -374,7 +386,7 @@
         ]
     },
     {
-        "event_id": "gen_new_cat_anykittypet3",
+        "event_id": "gen_new_cat_anykittypet4",
         "biome": ["any"],
         "camp": ["any"],
         "season": ["any"],
@@ -388,7 +400,6 @@
             ]
         ]
     },
-
     {
         "event_id": "gen_new_cat_anyrogue1",
         "biome": ["any"],
@@ -396,6 +407,10 @@
         "season": ["any"],
         "weight": 20,
         "event_text": "m_c finds a rogue named n_c_pre, who joins the Clan. The rogue decides to keep {PRONOUN/n_c/poss} old name.",
+        "m_c": {
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "status": ["any"]
+        },
         "new_cat": [
             [
                 "old_name",
@@ -411,6 +426,10 @@
         "season": ["any"],
         "weight": 20,
         "event_text": "m_c finds a rogue named n_c_pre, who joins the Clan. The rogue decides to take on a more Clan-like name, and is now called n_c.",
+        "m_c": {
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "status": ["any"]
+        },
         "new_cat": [
             [
                 "new_name",
@@ -457,6 +476,10 @@
         "season": ["any"],
         "weight": 20,
         "event_text": "m_c finds a warrior from o_c named n_c, who asks to join the Clan.",
+        "m_c": {
+            "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
+            "status": ["any"]
+        },
         "new_cat": [
             [
                 "old_name",

--- a/resources/dicts/events/new_cat/general.json
+++ b/resources/dicts/events/new_cat/general.json
@@ -4,7 +4,7 @@
         "biome": ["any"],
         "camp": ["any"],
         "season": ["any"],
-        "sub_types": ["adoption"],
+        "sub_type": ["adoption"],
         "weight": 20,
         "event_text": "A loner leaves their litter to the Clan. m_c decides to adopt them as {PRONOUN/m_c/poss} own.",
         "m_c": {
@@ -29,7 +29,7 @@
         "biome": ["any"],
         "camp": ["any"],
         "season": ["any"],
-         "sub_types": ["adoption"],
+         "sub_type": ["adoption"],
         "weight": 10,
         "event_text": "A rogue leaves their litter to the Clan. m_c decides to adopt them as {PRONOUN/m_c/poss} own.",
         "m_c": {
@@ -54,7 +54,7 @@
         "biome": ["any"],
         "camp": ["any"],
         "season": ["any"],
-         "sub_types": ["adoption"],
+         "sub_type": ["adoption"],
         "weight": 10,
         "event_text": "A o_c queen decides to leave their litter with you. m_c takes them as {PRONOUN/m_c/poss} own.",
         "m_c": {
@@ -79,7 +79,7 @@
         "biome": ["any"],
         "camp": ["any"],
         "season": ["any"],
-         "sub_types": ["adoption"],
+         "sub_type": ["adoption"],
         "weight": 5,
         "event_text": "A kittypet leaves their litter to the Clan. m_c decides to adopt them as {PRONOUN/m_c/poss} own.",
         "m_c": {
@@ -104,7 +104,7 @@
         "biome": ["any"],
         "camp": ["any"],
         "season": ["any"],
-         "sub_types": ["adoption"],
+         "sub_type": ["adoption"],
         "weight": 20,
         "event_text": "m_c finds an abandoned litter, and decides to adopt them as {PRONOUN/m_c/poss} own.",
         "m_c": {
@@ -514,7 +514,7 @@
         "biome": ["any"],
         "camp": ["any"],
         "season": ["any"],
-        "sub_types": ["war"],
+        "sub_type": ["war"],
         "weight": 15,
         "event_text": "A member of o_c defects in the war and chooses to join c_n. {PRONOUN/n_c/subject/CAP} {VERB/n_c/decide/decides} to keep {PRONOUN/n_c/poss} name.",
         "new_cat": [
@@ -530,7 +530,7 @@
         "biome": ["any"],
         "camp": ["any"],
         "season": ["any"],
-        "sub_types": ["war"],
+        "sub_type": ["war"],
         "weight": 10,
         "event_text": "n_c, the deputy of o_c, has defected to c_n in the war. {PRONOUN/n_c/subject/CAP} {VERB/n_c/decide/decides} to keep {PRONOUN/n_c/poss} name.",
         "new_cat": [
@@ -546,7 +546,7 @@
         "biome": ["any"],
         "camp": ["any"],
         "season": ["any"],
-        "sub_types": ["war"],
+        "sub_type": ["war"],
         "weight": 15,
         "event_text": "n_c, the medicine cat of o_c, has defected to c_n in the war. {PRONOUN/n_c/subject/CAP} {VERB/n_c/decide/decides} to keep {PRONOUN/n_c/poss} name.",
         "new_cat": [

--- a/resources/dicts/events/new_cat/general.json
+++ b/resources/dicts/events/new_cat/general.json
@@ -125,7 +125,7 @@
         "camp": ["any"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "m_c finds an abandoned kit and names {PRONOUN/n_c/object} n_c.",
+        "event_text": "m_c finds an abandoned kit and names {PRONOUN/n_c/object} n_c:0.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
             "status": ["any"]
@@ -144,7 +144,7 @@
         "camp": ["any"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "A loner brings their kit named n_c_pre to the Clan, stating they no longer can care for {PRONOUN/n_c/object}.",
+        "event_text": "A loner brings their kit named n_c_pre:1 to the Clan, stating they no longer can care for {PRONOUN/n_c/object}.",
         "new_cat": [
             ["age:has_kits", "meeting", "loner", "can_birth"],
             [
@@ -161,7 +161,7 @@
         "camp": ["any"],
         "season": ["any"],
         "weight": 10,
-        "event_text": "A kittypet brings their kit named n_c_pre to the Clan, stating they no longer can care for {PRONOUN/n_c/object}.",
+        "event_text": "A kittypet brings their kit named n_c_pre:1 to the Clan, stating they no longer can care for {PRONOUN/n_c/object}.",
         "new_cat": [
             ["age:has_kits", "meeting", "kittypet", "can_birth"],
             [
@@ -178,7 +178,7 @@
         "camp": ["any"],
         "season": ["any"],
         "weight": 5,
-        "event_text": "A rogue brings their kit named n_c_pre to the Clan, stating they no longer can care for {PRONOUN/n_c/object}.",
+        "event_text": "A rogue brings their kit named n_c_pre:1 to the Clan, stating they no longer can care for {PRONOUN/n_c/object}.",
         "new_cat": [
             ["age:has_kits", "meeting", "rogue", "can_birth"],
             [
@@ -252,7 +252,7 @@
         "camp": ["any"],
         "season": ["any"],
         "weight": 15,
-        "event_text": "m_c finds a loner named n_c_pre, who joins the Clan. The loner decides to keep {PRONOUN/n_c/poss} old name.",
+        "event_text": "m_c finds a loner named n_c_pre:0, who joins the Clan. The loner decides to keep {PRONOUN/n_c/poss} old name.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
             "status": ["any"]
@@ -271,7 +271,7 @@
         "camp": ["any"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "A loner waits on the border for a patrol, asking to join the Clan. The loner decides to take on a more Clan-like name, and is now called n_c.",
+        "event_text": "A loner waits on the border for a patrol, asking to join the Clan. The loner decides to take on a more Clan-like name, and is now called n_c:0.",
         "new_cat": [
             [
                 "new_name",
@@ -286,7 +286,7 @@
         "camp": ["any"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "A loner waits on the border for a patrol, asking to join the Clan. The loner decides to keep {PRONOUN/n_c/poss} old name, n_c.",
+        "event_text": "A loner waits on the border for a patrol, asking to join the Clan. The loner decides to keep {PRONOUN/n_c/poss} old name, n_c_pre:0.",
         "new_cat": [
             [
                 "old_name",
@@ -301,7 +301,7 @@
         "camp": ["any"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "m_c finds a loner named n_c_pre, who joins the Clan. The loner decides to take on a more Clan-like name, and is now called n_c.",
+        "event_text": "m_c finds a loner named n_c_pre:0, who joins the Clan. The loner decides to take on a more Clan-like name, and is now called n_c:0.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
             "status": ["any"]
@@ -320,7 +320,7 @@
         "camp": ["any"],
         "season": ["any"],
         "weight": 15,
-        "event_text": "While the Clan has no love for outsiders, sometimes new blood is needed. A patrol heads out and finds a wandering cat to bring into the Clan. The new cat, n_c_pre takes on a more Clan-like name.",
+        "event_text": "While the Clan has no love for outsiders, sometimes new blood is needed. A patrol heads out and finds a wandering cat to bring into the Clan. The new cat, n_c_pre:0 takes on a more Clan-like name and is now known as n_c:0.",
         "new_cat": [
             [
                 "new_name",
@@ -338,7 +338,7 @@
         "camp": ["any"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "m_c finds a kittypet named n_c_pre, who joins the Clan. The kittypet decides to keep {PRONOUN/n_c/poss} old name.",
+        "event_text": "m_c finds a kittypet named n_c_pre:0, who joins the Clan. The kittypet decides to keep {PRONOUN/n_c/poss} old name.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
             "status": ["any"]
@@ -357,7 +357,7 @@
         "camp": ["any"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "m_c finds a kittypet named n_c_pre, who joins the Clan. The kittypet decides to take on a more Clan-like name, and is now called n_c.",
+        "event_text": "m_c finds a kittypet named n_c_pre:0, who joins the Clan. The kittypet decides to take on a more Clan-like name, and is now called n_c:0.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
             "status": ["any"]
@@ -376,7 +376,7 @@
         "camp": ["any"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "A kittypet waits on the border for a patrol, asking to join the Clan. The kittypet decides to keep {PRONOUN/n_c/poss} old name, n_c.",
+        "event_text": "A kittypet waits on the border for a patrol, asking to join the Clan. The kittypet decides to keep {PRONOUN/n_c/poss} old name, n_c_pre:0.",
         "new_cat": [
             [
                 "old_name",
@@ -391,7 +391,7 @@
         "camp": ["any"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "A kittypet waits on the border for a patrol, asking to join the Clan. The kittypet decides to take on a more Clan-like name, and is now called n_c.",
+        "event_text": "A kittypet waits on the border for a patrol, asking to join the Clan. The kittypet decides to take on a more Clan-like name, and is now called n_c:0.",
         "new_cat": [
             [
                 "new_name",
@@ -406,7 +406,7 @@
         "camp": ["any"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "m_c finds a rogue named n_c_pre, who joins the Clan. The rogue decides to keep {PRONOUN/n_c/poss} old name.",
+        "event_text": "m_c finds a rogue named n_c_pre:0, who joins the Clan. The rogue decides to keep {PRONOUN/n_c/poss} old name.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
             "status": ["any"]
@@ -425,7 +425,7 @@
         "camp": ["any"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "m_c finds a rogue named n_c_pre, who joins the Clan. The rogue decides to take on a more Clan-like name, and is now called n_c.",
+        "event_text": "m_c finds a rogue named n_c_pre:0, who joins the Clan. The rogue decides to take on a more Clan-like name, and is now called n_c:0.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
             "status": ["any"]
@@ -444,7 +444,7 @@
         "camp": ["any"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "A rogue waits on the border for a patrol, asking to join the Clan. The rogue decides to keep {PRONOUN/n_c/poss} old name, n_c.",
+        "event_text": "A rogue waits on the border for a patrol, asking to join the Clan. The rogue decides to keep {PRONOUN/n_c/poss} old name, n_c_pre:0.",
         "new_cat": [
             [
                 "old_name",
@@ -459,7 +459,7 @@
         "camp": ["any"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "A rogue waits on the border for a patrol, asking to join the Clan. The rogue decides to keep {PRONOUN/n_c/poss} old name, n_c.",
+        "event_text": "A rogue waits on the border for a patrol, asking to join the Clan. The rogue decides to keep {PRONOUN/n_c/poss} old name, n_c_pre:0.",
         "new_cat": [
             [
                 "new_name",
@@ -475,7 +475,7 @@
         "camp": ["any"],
         "season": ["any"],
         "weight": 20,
-        "event_text": "m_c finds a warrior from o_c named n_c, who asks to join the Clan.",
+        "event_text": "m_c finds a warrior from o_c named n_c_pre:0, who asks to join the Clan.",
         "m_c": {
             "age": ["adolescent", "young adult", "adult", "senior adult", "senior"],
             "status": ["any"]
@@ -532,7 +532,7 @@
         "season": ["any"],
         "sub_type": ["war"],
         "weight": 10,
-        "event_text": "n_c, the deputy of o_c, has defected to c_n in the war. {PRONOUN/n_c/subject/CAP} {VERB/n_c/decide/decides} to keep {PRONOUN/n_c/poss} name.",
+        "event_text": "n_c_pre:0, the deputy of o_c, has defected to c_n in the war. {PRONOUN/n_c/subject/CAP} {VERB/n_c/decide/decides} to keep {PRONOUN/n_c/poss} name.",
         "new_cat": [
           [
             "old_name", 
@@ -548,7 +548,7 @@
         "season": ["any"],
         "sub_type": ["war"],
         "weight": 15,
-        "event_text": "n_c, the medicine cat of o_c, has defected to c_n in the war. {PRONOUN/n_c/subject/CAP} {VERB/n_c/decide/decides} to keep {PRONOUN/n_c/poss} name.",
+        "event_text": "n_c_pre:0, the medicine cat of o_c, has defected to c_n in the war. {PRONOUN/n_c/subject/CAP} {VERB/n_c/decide/decides} to keep {PRONOUN/n_c/poss} name.",
         "new_cat": [
           [
             "old_name", 

--- a/resources/dicts/events/new_cat/general.json
+++ b/resources/dicts/events/new_cat/general.json
@@ -4,7 +4,7 @@
         "biome": ["any"],
         "camp": ["any"],
         "season": ["any"],
-        "tags": ["adoption"],
+        "sub_types": ["adoption"],
         "weight": 20,
         "event_text": "A loner leaves their litter to the Clan. m_c decides to adopt them as {PRONOUN/m_c/poss} own.",
         "m_c": {
@@ -29,7 +29,7 @@
         "biome": ["any"],
         "camp": ["any"],
         "season": ["any"],
-        "tags":["adoption"],
+         "sub_types": ["adoption"],
         "weight": 10,
         "event_text": "A rogue leaves their litter to the Clan. m_c decides to adopt them as {PRONOUN/m_c/poss} own.",
         "m_c": {
@@ -54,7 +54,7 @@
         "biome": ["any"],
         "camp": ["any"],
         "season": ["any"],
-        "tags": ["adoption"],
+         "sub_types": ["adoption"],
         "weight": 10,
         "event_text": "A o_c queen decides to leave their litter with you. m_c takes them as {PRONOUN/m_c/poss} own.",
         "m_c": {
@@ -79,7 +79,7 @@
         "biome": ["any"],
         "camp": ["any"],
         "season": ["any"],
-        "tags": ["adoption"],
+         "sub_types": ["adoption"],
         "weight": 5,
         "event_text": "A kittypet leaves their litter to the Clan. m_c decides to adopt them as {PRONOUN/m_c/poss} own.",
         "m_c": {
@@ -104,7 +104,7 @@
         "biome": ["any"],
         "camp": ["any"],
         "season": ["any"],
-        "tags": ["adoption"],
+         "sub_types": ["adoption"],
         "weight": 20,
         "event_text": "m_c finds an abandoned litter, and decides to adopt them as {PRONOUN/m_c/poss} own.",
         "m_c": {
@@ -514,7 +514,7 @@
         "biome": ["any"],
         "camp": ["any"],
         "season": ["any"],
-        "tags": ["war"],
+        "sub_types": ["war"],
         "weight": 15,
         "event_text": "A member of o_c defects in the war and chooses to join c_n. {PRONOUN/n_c/subject/CAP} {VERB/n_c/decide/decides} to keep {PRONOUN/n_c/poss} name.",
         "new_cat": [
@@ -530,7 +530,7 @@
         "biome": ["any"],
         "camp": ["any"],
         "season": ["any"],
-        "tags": ["war"],
+        "sub_types": ["war"],
         "weight": 10,
         "event_text": "n_c, the deputy of o_c, has defected to c_n in the war. {PRONOUN/n_c/subject/CAP} {VERB/n_c/decide/decides} to keep {PRONOUN/n_c/poss} name.",
         "new_cat": [
@@ -546,7 +546,7 @@
         "biome": ["any"],
         "camp": ["any"],
         "season": ["any"],
-        "tags": ["war"],
+        "sub_types": ["war"],
         "weight": 15,
         "event_text": "n_c, the medicine cat of o_c, has defected to c_n in the war. {PRONOUN/n_c/subject/CAP} {VERB/n_c/decide/decides} to keep {PRONOUN/n_c/poss} name.",
         "new_cat": [


### PR DESCRIPTION
Finishes reformatting all misc and new_cat events to the new format, fixes certain issues such as 
-kittens being confessed to murders
-making new_cat litter events generate a outsider

Some notes:

-used "clan" in relationship tags, I understand if it doesn't work and will be an easy patch if it ends up not working out
-No idea if my weights are balanced, just did what seemed right
-Added a 'test' event to see if new_cats can generate a polycat to join a couple. If it crashes, it's ID is gen_new_cat_anypolymate1