### PR TITLE
General death events

### DIFF
--- a/resources/dicts/events/death/beach.json
+++ b/resources/dicts/events/death/beach.json
@@ -1,7 +1,7 @@
 [
     {
         "event_id": "bch_death_drown_any1",
-        "biome": ["beach", ""],
+        "biome": ["beach"],
         "camp": [
             "any"
         ],
@@ -172,7 +172,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c drowned after being pushed out to sea by o_c warriors.",

--- a/resources/dicts/events/death/beach.json
+++ b/resources/dicts/events/death/beach.json
@@ -1,7 +1,7 @@
 [
     {
         "event_id": "bch_death_drown_any1",
-        "biome": ["beach"],
+        "biome": ["beach", ""],
         "camp": [
             "any"
         ],
@@ -138,33 +138,6 @@
         ]
     },
     {
-        "event_id": "bch_death_heat_greenleaf1",
-        "biome": [ "beach" ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf"
-        ],
-        "tags": [
-            "classic"
-        ],
-        "weight": 20,
-        "event_text": "m_c died from dehydration and heat stroke.",
-        "m_c": {
-            "age": [ "any" ],
-            "status": [ "any" ],
-            "dies": true
-        },
-        "history":
-        [ {
-            "cats": ["m_c"],
-            "reg_death": "m_c died of dehydration and heat stroke.",
-            "lead_death": "died of dehydration and heat stroke"
-        }
-    ]
-    },
-    {
         "event_id": "bch_death_abyss_any1",
         "biome": [ "beach" ],
         "camp": [
@@ -199,9 +172,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "m_c drowned after being pushed out to sea by o_c warriors.",
         "m_c": {
@@ -1152,34 +1124,4 @@
             "lead_death": "saved a drowning kit that was set up by r_c"
         }
     ]
-    },
-    {
-        "event_id": "bch_death_heat_anykit1",
-        "biome": [ "beach" ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf"
-        ],
-        "tags": [
-            "classic"
-        ],
-        "weight": 20,
-        "event_text": "m_c died from dehydration and heat stroke.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "dies": true
-        },
-        "history": [
-            {
-            "cats": [ "m_c" ],
-            "reg_death": "m_c died of dehydration and heat stroke."
-        }
-        ]
     }]

--- a/resources/dicts/events/death/forest.json
+++ b/resources/dicts/events/death/forest.json
@@ -1,57 +1,4 @@
-[    {
-        "event_id": "fst_death_",
-        "biome": [
-            "forest"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was found dead and cold in the snow.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "dies": true
-        },
-        "history": {
-            "reg_death": "m_c froze to death."
-        }
-    },
-    {
-        "event_id": "fst_death_",
-        "biome": [
-            "forest"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c froze to death during a harsh snowstorm.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "dies": true
-        },
-        "history": {
-            "reg_death": "m_c froze to death."
-        }
-    },
+[
     {
         "event_id": "fst_death_",
         "biome": [
@@ -126,35 +73,6 @@
             "any"
         ],
         "season": [
-            "greenleaf"
-        ],
-        "tags": [
-            "classic"
-        ],
-        "weight": 20,
-        "event_text": "m_c died from dehydration and heat stroke.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "dies": true
-        },
-        "history": {
-            "reg_death": "m_c died of dehydration and heat stroke."
-        }
-    },
-    {
-        "event_id": "fst_death_",
-        "biome": [
-            "forest"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
             "leaf-fall",
             "leaf-bare"
         ],
@@ -173,6 +91,7 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was eaten by a predator."
         }
     },
@@ -203,6 +122,7 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was eaten by a predator."
         }
     },
@@ -231,6 +151,7 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was killed by a feisty mouse."
         }
     },
@@ -261,6 +182,7 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was eaten by a shrew."
         }
     },
@@ -272,9 +194,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "m_c was killed by a falling branch during a battle in a heavily wooded area of the forest.",
         "m_c": {
@@ -283,6 +204,7 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was squished by a falling branch.",
             "lead_death": "was squished by a falling branch."
         }
@@ -296,10 +218,8 @@
             "newleaf",
             "leaf-bare"
         ],
-        "tags": [
-            "murder",
-            "revealed"
-        ],
+        "sub_type": [ "murder", "revealed" ],
+        "tags": [],
         "weight": 20,
         "event_text": "m_c agreed to venture with r_c out onto a frozen pond. m_c went first while r_c hung back. m_c slid around playfully, taunting the other cat to chase {PRONOUN/m_c/object}. {PRONOUN/m_c/subject/CAP} {VERB/m_c/were/was} about to launch another teasing remark when the ice cracked below {PRONOUN/m_c/poss} paws. r_c lingered to make sure {PRONOUN/m_c/subject} didn't surface before running back to camp with a yowl.",
         "m_c": {
@@ -325,6 +245,7 @@
             "status": []
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was lured onto thin ice by r_c, resulting in {PRONOUN/m_c/poss} death."
         },
         "relationships": [

--- a/resources/dicts/events/death/forest.json
+++ b/resources/dicts/events/death/forest.json
@@ -218,7 +218,7 @@
             "newleaf",
             "leaf-bare"
         ],
-        "sub_type": [ "murder", "revealed" ],
+        "sub_type": [ "murder" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c agreed to venture with r_c out onto a frozen pond. m_c went first while r_c hung back. m_c slid around playfully, taunting the other cat to chase {PRONOUN/m_c/object}. {PRONOUN/m_c/subject/CAP} {VERB/m_c/were/was} about to launch another teasing remark when the ice cracked below {PRONOUN/m_c/poss} paws. r_c lingered to make sure {PRONOUN/m_c/subject} didn't surface before running back to camp with a yowl.",

--- a/resources/dicts/events/death/forest.json
+++ b/resources/dicts/events/death/forest.json
@@ -91,7 +91,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was eaten by a predator."
         }
     },
@@ -122,7 +122,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was eaten by a predator."
         }
     },
@@ -151,7 +151,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was killed by a feisty mouse."
         }
     },
@@ -182,7 +182,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was eaten by a shrew."
         }
     },
@@ -194,7 +194,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was killed by a falling branch during a battle in a heavily wooded area of the forest.",
@@ -204,9 +204,9 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was squished by a falling branch.",
-            "lead_death": "was squished by a falling branch."
+            "lead_death": "{VERB/m_c/were/was} squished by a falling branch."
         }
     },
     {
@@ -219,12 +219,12 @@
             "leaf-bare"
         ],
         "sub_type": [ "murder" ],
-        "tags": [],
+        "tags": [ "all_lives" ],
         "weight": 20,
         "event_text": "m_c agreed to venture with r_c out onto a frozen pond. m_c went first while r_c hung back. m_c slid around playfully, taunting the other cat to chase {PRONOUN/m_c/object}. {PRONOUN/m_c/subject/CAP} {VERB/m_c/were/was} about to launch another teasing remark when the ice cracked below {PRONOUN/m_c/poss} paws. r_c lingered to make sure {PRONOUN/m_c/subject} didn't surface before running back to camp with a yowl.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "any" ],
+            "status": [ "any" ],
             "relationship_status": [],
             "not_skill": [
                 "PROPHET,3",
@@ -245,7 +245,7 @@
             "status": []
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was lured onto thin ice by r_c, resulting in {PRONOUN/m_c/poss} death."
         },
         "relationships": [

--- a/resources/dicts/events/death/general.json
+++ b/resources/dicts/events/death/general.json
@@ -1,30 +1,5 @@
 [
     {
-        "event_id": "gen_death_heat_greenleaf1",
-        "biome": [ "forest", "beach", "plains" ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf"
-        ],
-        "tags": [
-            "classic"
-        ],
-        "weight": 20,
-        "event_text": "m_c died from dehydration and heat stroke.",
-        "m_c": {
-            "age": [ "any" ],
-            "status": [ "any"],
-            "dies": true
-        },
-        "history": {
-            "cats": "m_c",
-            "reg_death": "m_c died of dehydration and heat stroke.",
-            "lead_death": "died of dehydration and heat stroke"
-        }
-    },
-    {
         "event_id": "gen_death_murder_any1",
         "biome": [ "any" ],
         "camp": [
@@ -48,7 +23,7 @@
             "status": [ "any" ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "reg_death": "m_c was secretly murdered by r_c."
         },
         "relationships": [
@@ -105,7 +80,7 @@
             ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "reg_death": "m_c was murdered by r_c."
         },
         "relationships": [
@@ -145,8 +120,7 @@
             "any"
         ],
         "sub_type":  [
-            "murder",
-            "murder_reveal"
+            "murder"
         ],
         "tags": [],
         "weight": 20,
@@ -168,7 +142,7 @@
             ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "reg_death": "m_c was murdered by r_c."
         },
         "relationships": [
@@ -228,7 +202,7 @@
             ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "reg_death": "m_c was secretly murdered by r_c, who made the death look accidental."
         },
         "relationships": [
@@ -273,7 +247,7 @@
         "event_text": "r_c killed m_c by feeding {PRONOUN/m_c/object} deathberries.",
         "m_c": {
             "age": [ "any" ],
-            "status": ["kitten", "apprentice", "medicine cat apprentice", "medicine cat", "mediator", "mediator apprentice", "deputy", "warrior", "elder" ],
+            "status": ["kitten", "apprentice", "medicine cat apprentice", "mediator", "mediator apprentice", "deputy", "warrior", "elder" ],
             "not_skill": [
                 "CLEVER,2"
             ],
@@ -284,7 +258,7 @@
             "status": [ "medicine cat apprentice", "medicine cat" ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "reg_death": "m_c was murdered by r_c, who fed {PRONOUN/m_c/object} deathberries."
         },
         "relationships": [
@@ -330,7 +304,7 @@
         "event_text": "r_c killed m_c by feeding {PRONOUN/m_c/object} foxglove seeds.",
         "m_c": {
             "age": [ "any" ],
-            "status": ["kitten", "apprentice", "medicine cat apprentice", "medicine cat", "mediator", "mediator apprentice", "deputy", "warrior", "elder"],
+            "status": ["kitten", "apprentice", "medicine cat apprentice", "mediator", "mediator apprentice", "deputy", "warrior", "elder"],
             "not_skill": [
                 "CLEVER,2"
             ],
@@ -341,7 +315,7 @@
             "status": [ "medicine cat apprentice", "medicine cat" ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "reg_death": "m_c was murdered by r_c, who fed {PRONOUN/m_c/object} foxglove seeds."
         },
         "relationships": [
@@ -387,7 +361,7 @@
         "event_text": "r_c killed m_c by feeding {PRONOUN/m_c/object} nightshade berries.",
         "m_c": {
             "age": [ "any" ],
-            "status": [ "kitten", "apprentice", "medicine cat apprentice", "medicine cat", "mediator", "mediator apprentice", "deputy", "warrior", "elder" ],
+            "status": [ "kitten", "apprentice", "medicine cat apprentice", "mediator", "mediator apprentice", "deputy", "warrior", "elder" ],
             "not_skill": [
                 "CLEVER,2"
             ],
@@ -398,7 +372,7 @@
             "status": [ "medicine cat apprentice", "medicine cat" ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "reg_death": "m_c was murdered by r_c, who fed {PRONOUN/m_c/object} nightshade berries."
         },
         "relationships": [
@@ -444,7 +418,7 @@
         "event_text": "r_c killed m_c by feeding {PRONOUN/m_c/object} water hemlock.",
         "m_c": {
             "age": [ "any" ],
-            "status": [ "kitten", "apprentice", "medicine cat apprentice", "medicine cat", "mediator", "mediator apprentice", "deputy", "warrior", "elder"],
+            "status": [ "kitten", "apprentice", "medicine cat apprentice", "mediator", "mediator apprentice", "deputy", "warrior", "elder"],
             "not_skill": [
                 "CLEVER,2"
             ],
@@ -455,7 +429,7 @@
             "status": [ "medicine cat apprentice", "medicine cat" ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "reg_death": "m_c was murdered by r_c, who fed {PRONOUN/m_c/object} water hemlock."
         },
         "relationships": [
@@ -501,7 +475,7 @@
         "event_text": "r_c killed m_c by consciously giving {PRONOUN/m_c/object} the wrong herbs.",
         "m_c": {
             "age": [ "any" ],
-            "status": [ "kitten", "apprentice", "medicine cat apprentice", "medicine cat", "mediator", "mediator apprentice", "deputy", "warrior", "elder"],
+            "status": [ "kitten", "apprentice", "medicine cat apprentice", "mediator", "mediator apprentice", "deputy", "warrior", "elder"],
             "not_skill": [
                 "CLEVER,2"
             ],
@@ -512,7 +486,7 @@
             "status": [ "medicine cat apprentice", "medicine cat" ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "reg_death": "m_c was murdered by r_c, who purposefully fed {PRONOUN/m_c/object} the wrong herbs."
         },
         "relationships": [
@@ -573,8 +547,9 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
-            "reg_death": "m_c was killed by a fox."
+            "cats": ["m_c"],
+            "reg_death": "m_c was killed by a fox.",
+            "lead_death": "{VERB/m_c/were/was} killed by a fox"
         }
     },
     {
@@ -595,7 +570,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was killed by a snake.",
             "lead_death": "{VERB/m_c/were/was} bitten by a snake"
         }
@@ -637,7 +612,7 @@
             "status": [ "any" ]
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was killed by a snake while saving a kit.",
             "lead_death": "died saving a kit from a snake"
         }
@@ -660,7 +635,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c went missing and was found dead."
         }
     },
@@ -685,7 +660,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was found dead near the o_c border."
         },
         "other_clan": {
@@ -766,10 +741,49 @@
             "status": [ "any" ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "reg_death": "m_c died defending r_c from o_c warriors.",
             "lead_death": "died defending the nursery"
         },
+        "relationships": [
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "platonic",
+                    "respect"
+                ],
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "trust"
+                ],
+                "amount": 25
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": -15
+            }
+        ],
         "other_clan": {
             "current_rep": [
                 "hostile"
@@ -812,7 +826,7 @@
             "status": [ "any" ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "reg_death": "m_c was killed in a fire while trying to save r_c.",
             "lead_death": "{VERB/m_c/were/was} burnt alive saving r_c"
         },
@@ -865,7 +879,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c died of greencough.",
             "lead_death": "died of greencough"
         }
@@ -890,7 +904,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c died from infected wounds.",
             "lead_death": "died from infected wounds"
         }
@@ -939,9 +953,8 @@
         "weight": 20,
         "event_text": "m_c fell into the river, and r_c drowned alongside m_c while trying to rescue {PRONOUN/m_c/object}.",
         "m_c": {
-            "age": [ "any" ],
+            "age": [ "adolescent", "young adult", "adult", "senior adult", "senior" ],
             "status": [ "any" ],
-            "relationship_status": [],
             "dies": true
         },
         "r_c": {
@@ -967,7 +980,7 @@
         },
         "history": {
             "cats": ["m_c", "r_c"],
-            "reg_death": "m_c drowned alongside a Clanmate.",
+            "reg_death": "This cat drowned alongside a Clanmate.",
             "lead_death": "drowned alongside a Clanmate"
         }
     },
@@ -1032,7 +1045,7 @@
         },
         "history": {
             "cats": ["m_c", "r_c"],
-            "reg_death": "m_c died of greencough.",
+            "reg_death": "This cat died of greencough.",
             "lead_death": "died of greencough"
         }
     },
@@ -1062,7 +1075,7 @@
         },
         "history": {
             "cats": ["m_c", "r_c"],
-            "reg_death": "m_c died of yellowcough.",
+            "reg_death": "This cat died of yellowcough.",
             "lead_death": "died of yellowcough"
         }
     },
@@ -1092,7 +1105,7 @@
         },
         "history": {
             "cats": ["m_c", "r_c"],
-            "reg_death": "m_c died of greencough.",
+            "reg_death": "This cat died of greencough.",
             "lead_death": "died of greencough"
         }
     },
@@ -1119,7 +1132,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "Curiosity killed this cat."
         }
     },
@@ -1132,7 +1145,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c sacrificed {PRONOUN/m_c/self} for r_c in a battle with o_c.",
@@ -1146,7 +1159,7 @@
             "status": [ "apprentice", "warrior", "deputy", "leader" ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "reg_death": "m_c sacrificed {PRONOUN/m_c/self} for r_c in battle.",
             "lead_death": "sacrificed {PRONOUN/m_c/self} for r_c in battle."
         },
@@ -1188,7 +1201,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c threw {PRONOUN/m_c/self} in front of an oncoming attack meant for r_c, taking the deadly blow instead.",
@@ -1202,7 +1215,7 @@
             "status": [ "apprentice", "warrior", "deputy", "leader" ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "reg_death": "m_c sacrificed {PRONOUN/m_c/self} for r_c in battle.",
             "lead_death": "sacrificed {PRONOUN/m_c/self} for r_c in battle."
         },
@@ -1244,10 +1257,10 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
-        "event_text": "m_c intentionally stayed behind and fought a losing battle to give r_c time to escape.",
+        "event_text": "m_c stayed behind and fought a losing battle to give r_c time to escape.",
         "m_c": {
             "age": [ "adolescent", "young adult", "adult", "senior adult" ],
             "status": [ "apprentice", "warrior", "deputy", "leader" ],
@@ -1258,7 +1271,7 @@
             "status": [ "apprentice", "warrior", "deputy", "leader" ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "reg_death": "m_c sacrificed {PRONOUN/m_c/self} for r_c in battle.",
             "lead_death": "sacrificed {PRONOUN/m_c/self} for r_c in battle."
         },
@@ -1300,7 +1313,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "When traveling together near the border of c_n territory, m_c used {PRONOUN/m_c/poss} own body to shield r_c from a surprise o_c ambush, even though it meant certain death.",
@@ -1314,7 +1327,7 @@
             "status": [ "any" ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "reg_death": "m_c sacrificed {PRONOUN/m_c/self} for r_c in an ambush.",
             "lead_death": "sacrificed {PRONOUN/m_c/self} for r_c in an ambush."
         },
@@ -1356,7 +1369,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c sacrificed {PRONOUN/m_c/self} by taking on the role of a messenger, delivering important information that could save {PRONOUN/m_c/poss} Clan. {PRONOUN/m_c/subject/CAP} {VERB/m_c/were/was} killed while investigating enemy territory.",
@@ -1366,9 +1379,8 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
-            "reg_death": "m_c was killed investigating enemy territory.",
-            "lead_death": "{VERB/m_c/were/was} killed investigating enemy territory."
+            "cats": ["m_c"],
+            "reg_death": "m_c was killed investigating enemy territory."
         }
     },
     {
@@ -1382,17 +1394,18 @@
             "newleaf",
             "greenleaf"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c drowned in a river while trying to escape from a sudden o_c attack.",
         "m_c": {
             "age": [ "adolescent", "young adult", "adult", "senior adult" ],
             "status": ["apprentice", "warrior", "deputy", "leader"],
+            "not_skill": ["SWIMMER,2"],
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c drowned in a river attempting to escape an enemy attack.",
             "lead_death": "drowned in a river attempting to escape an enemy attack."
         }
@@ -1406,7 +1419,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [ "some_lives" ],
         "weight": 20,
         "event_text": "m_c fell into a pit trap set by o_c's warriors.",
@@ -1416,7 +1429,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c fell into a pit trap set by an enemy Clan.",
             "lead_death": "fell into a pit trap set by an enemy Clan."
         }
@@ -1430,7 +1443,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [ "some_lives" ],
         "weight": 20,
         "event_text": "m_c was hit by a monster while escaping across a Thunderpath from o_c warriors.",
@@ -1440,7 +1453,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was hit by a monster.",
             "lead_death": "{VERB/m_c/were/was} hit by a monster."
         }
@@ -1459,12 +1472,12 @@
         "weight": 20,
         "event_text": "m_c wandered out into the territory and was later found dead, a peaceful expression on {PRONOUN/m_c/poss} face.",
         "m_c": {
-            "age": [ "senior adult", "senior" ],
+            "age": [ "senior" ],
             "status": [ "warrior", "medicine cat", "mediator", "elder" ],
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c died of old age."
         }
     },
@@ -1484,12 +1497,12 @@
         "weight": 20,
         "event_text": "m_c was found stiff and curled up in {PRONOUN/m_c/poss} nest. It seems {PRONOUN/m_c/subject} died in {PRONOUN/m_c/poss} sleep.",
         "m_c": {
-            "age": [ "senior adult", "senior" ],
+            "age": [ "senior" ],
             "status": [ "warrior", "medicine cat", "mediator", "elder" ],
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c died of old age."
         }
     },
@@ -1509,12 +1522,12 @@
         "weight": 20,
         "event_text": "m_c faded more and more as the days went by, until one day, {PRONOUN/m_c/subject} {VERB/m_c/were/was} found dead in {PRONOUN/m_c/poss} nest.",
         "m_c": {
-            "age": [ "senior adult", "senior" ],
+            "age": [ "senior" ],
             "status": [ "warrior", "medicine cat", "mediator", "elder" ],
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c died of old age."
         }
     },
@@ -1534,7 +1547,7 @@
         "weight": 20,
         "event_text": "m_c is suddenly struck by a sharp pain in {PRONOUN/m_c/poss} chest. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} found later that day, cold.",
         "m_c": {
-            "age": [ "senior adult", "senior" ],
+            "age": [ "senior" ],
             "status": [ "warrior", "medicine cat", "mediator", "elder" ],
             "dies": true
         },
@@ -1557,7 +1570,7 @@
         "weight": 20,
         "event_text": "m_c and r_c loved each other so much they could not be parted, even by death. c_n finds their bodies still wrapped around each other in the morning.",
         "m_c": {
-            "age": [ "senior adult", "senior" ],
+            "age": [ "senior" ],
             "status": [ "any" ],
             "relationship_status": [
                 "mates"
@@ -1565,13 +1578,13 @@
             "dies": true
         },
         "r_c": {
-            "age": [ "senior adult", "senior" ],
+            "age": [ "senior" ],
             "status": [ "any" ],
             "dies": true
         },
         "history": {
             "cats": ["m_c", "r_c"],
-            "reg_death": "This cat died from old age life.",
+            "reg_death": "This cat died from old age.",
             "lead_death": "lost all remaining lives from old age."
         }
     },
@@ -1584,16 +1597,16 @@
         "season": [
             "any"
         ],
-        "tags": [],
+        "tags": [ "no_body" ],
         "weight": 20,
-        "event_text": "m_c couldn't miss today! Such a bright day, perfect for a walk. That was until m_c detected another scent, a strong one, and a foul one. {PRONOUN/m_c/subject/CAP} scrambled away from the area, but not before abnormally long claws slashed across their face.",
+        "event_text": "m_c couldn't miss today! Such a bright day, perfect for a walk. That was until m_c detected another scent, a strong one, and a foul one. {PRONOUN/m_c/subject/CAP} recoiled, but not before abnormally long claws slashed across their face. Later, c_n found only blood and the scent of a predator at the scene.",
         "m_c": {
             "age": [ "adolescent", "young adult", "adult", "senior adult" ],
             "status": [ "any" ],
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was killed by an unknown predator."
         }
     },
@@ -1641,7 +1654,7 @@
             ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "reg_death": "m_c was murdered by r_c."
         },
         "relationships": [
@@ -1774,10 +1787,10 @@
         },
         "r_c": {
             "age": [ "any" ],
-            "status": [ "warrior" ]
+            "status": [ "warrior", "deputy" ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "reg_death": "m_c {VERB/m_c/were/was} pushed into a ravine by r_c.",
             "lead_death": "{VERB/were/was} pushed into a ravine by r_c"
         },
@@ -1811,22 +1824,21 @@
         ]
     },
     {
-        "event_id": "gen_death_murder_multiice1",
+        "event_id": "gen_death_murder_leafbareice1",
         "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
-            "newleaf",
             "leaf-bare"
         ],
         "sub_type": [ "murder" ],
-        "tags": [],
+        "tags": [ "all_lives" ],
         "weight": 20,
         "event_text": "m_c agreed to venture with r_c out onto a frozen pond. m_c went first while r_c hung back. m_c slid around playfully, taunting the other cat to chase {PRONOUN/m_c/object}. {PRONOUN/m_c/subject/CAP} {VERB/m_c/were/was} about to launch another teasing remark when the ice cracked below {PRONOUN/m_c/poss} paws. r_c lingered to make sure {PRONOUN/m_c/subject} didn't surface before running back to camp with a yowl.",
         "m_c": {
-            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
-            "status":  ["apprentice", "mediator apprentice", "medicine cat apprentice", "warrior", "medicine cat", "mediator", "deputy"],
+            "age": [ "adolescent", "young adult", "adult", "senior adult", "senior" ],
+            "status":  ["any"],
             "not_skill": [
                 "PROPHET,3",
                 "OMEN,3",
@@ -1846,8 +1858,9 @@
             "status": [ "any" ]
         },
         "history": {
-            "cats": ["m_c", "r_c" ],
-            "reg_death": "m_c was lured onto thin ice by r_c, resulting in {PRONOUN/m_c/poss} death."
+            "cats": ["m_c" ],
+            "reg_death": "m_c was lured onto thin ice by r_c, resulting in {PRONOUN/m_c/poss} death.",
+            "lead_death": "{VERB/m_c/were/was} lured onto thin ice by r_c and fell through, becoming trapped underwater"
         },
         "relationships": [
             {
@@ -1951,7 +1964,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c fell into a sinkhole."
         }
     },
@@ -1973,14 +1986,14 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c fell into a hidden burrow.",
             "lead_death": "{VERB/m_c/were/was buried alive in a hidden burrow"
         }
     },
     {
         "event_id": "gen_death_bury_any2",
-        "biome": ["any"],
+        "biome": ["plains"],
         "camp": [
             "any"
         ],
@@ -1996,13 +2009,13 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was buried alive when a burrow collapsed.",
             "lead_death": "{VERB/m_c/were/was} buried alive in a hidden burrow"
         }
     },
     {
-        "event_id": "gen_death_heat_greenleaf2",
+        "event_id": "gen_death_heat_greenleaf1",
         "biome": ["any"],
         "camp": [
             "any"
@@ -2016,13 +2029,14 @@
         "weight": 20,
         "event_text": "m_c died from dehydration and heat stroke.",
         "m_c": {
-            "age": [ "kitten" ],
-            "status": [ "kitten" ],
+            "age": [ "any" ],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
-            "cats": "m_c",
-            "reg_death": "m_c died of dehydration and heat stroke."
+            "cats": ["m_c"],
+            "reg_death": "m_c died of dehydration and heat stroke.",
+            "lead_death": "died of dehydration and heat stroke"
         }
     },
     {
@@ -2043,7 +2057,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c froze to death."
         }
     },
@@ -2065,7 +2079,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c froze to death."
         }
     },
@@ -2078,7 +2092,7 @@
         "season": [
             "leaf-bare"
         ],
-        "tags": [ "some_lives" ],
+        "tags": [ "all_lives" ],
         "weight": 20,
         "event_text": "m_c was walking on the ice, when it cracked and {PRONOUN/m_c/subject} fell in.",
         "m_c": {
@@ -2087,7 +2101,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c froze to death after falling through ice.",
             "lead_death": "fell through thin ice and drowned"
         }
@@ -2102,7 +2116,7 @@
             "any"
         ],
         "sub_type": ["war"],
-        "tags": [],
+        "tags": [ "all_lives" ],
         "weight": 20,
         "event_text": "m_c was sealed in a cramped rabbit burrow by o_c warriors. {PRONOUN/m_c/subject/CAP} didn't make it out alive.",
         "m_c": {
@@ -2114,74 +2128,6 @@
             "reg_death": "m_c suffocated underground.",
             "lead_death": "{VERB/m_c/were/was} suffocated underground."
         }
-    },
-    {
-        "event_id": "gen_death_murder_multiice2",
-        "biome": ["any"],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "newleaf",
-            "leaf-bare"
-        ],
-        "sub_type": [ "murder" ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c agreed to venture with r_c out onto a frozen pond. m_c went first while r_c hung back. m_c slid around playfully, taunting the other cat to chase {PRONOUN/m_c/object}. {PRONOUN/m_c/subject/CAP} {VERB/m_c/were/was} about to launch another teasing remark when the ice cracked below {PRONOUN/m_c/poss} paws. r_c lingered to make sure {PRONOUN/m_c/subject} didn't surface before running back to camp with a yowl.",
-        "m_c": {
-            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
-            "status": [ "apprentice", "mediator apprentice", "medicine cat apprentice", "warrior", "medicine cat", "mediator", "deputy" ],
-            "not_skill": [
-                "PROPHET,3",
-                "OMEN,3",
-                "SWIMMER,3"
-            ],
-            "trait": [
-                "daring",
-                "adventurous",
-                "oblivious",
-                "bold",
-                "childish"
-            ],
-            "dies": true
-        },
-        "r_c": {
-            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
-            "status": [ "any" ]
-        },
-        "history": {
-            "cats": ["m_c", "r_c"],
-            "reg_death": "m_c was lured onto thin ice by r_c, resulting in {PRONOUN/m_c/poss} death."
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "dislike"
-                ],
-                "amount": 15
-            },
-            {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "trust",
-                    "comfort"
-                ],
-                "amount": -15
-            }
-        ]
     },
     {
         "event_id": "gen_death_skirmish_any1",
@@ -2212,7 +2158,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c died in a border skirmish against o_c.",
             "lead_death": "died in a border skirmish against o_c"
         },
@@ -2233,7 +2179,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "In the chaos of battle and the throes of a war, it's nearly impossible to tell friend from foe. Blinded by blood, r_c accidentally kills m_c.",
@@ -2259,7 +2205,7 @@
             "status": [ "warrior", "deputy", "leader" ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "reg_death": "m_c was accidentally killed by r_c in battle.",
             "lead_death": "{VERB/m_c/were/was} accidentally killed by r_c in battle"
         },
@@ -2319,7 +2265,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was killed while trying to save o_c's medicine cat.",
             "lead_death": "{VERB/m_c/were/was} killed while trying to save o_c's medicine cat"
         },
@@ -2360,7 +2306,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was killed by the deputy of o_c.",
             "lead_death": "{VERB/m_c/were/was} killed by the deputy of o_c"
         },
@@ -2413,7 +2359,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was killed while trying to save o_c's deputy.",
             "lead_death": "{VERB/m_c/were/was} killed while trying to save o_c's deputy"
         },
@@ -2454,7 +2400,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was killed by the leader of o_c.",
             "lead_death": "{VERB/m_c/were/was} killed by the leader of o_c"
         },
@@ -2507,7 +2453,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was killed while trying to save o_c's leader.",
             "lead_death": "{VERB/m_c/were/was} killed while trying to save o_c's leader"
         },
@@ -2561,7 +2507,7 @@
         },
         "history": {
             "cats": ["m_c", "r_c"],
-            "reg_death": "m_c died in a border skirmish against o_c.",
+            "reg_death": "This cat died in a border skirmish against o_c.",
             "lead_death": "was killed in a border skirmish against o_c."
         },
         "other_clan": {
@@ -2591,7 +2537,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was buried alive in an avalanche.",
             "lead_death": "{VERB/m_c/were/was} buried alive in an avalanche"
         }
@@ -2616,14 +2562,14 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was buried alive in a landslide.",
             "lead_death": "{VERB/m_c/were/was} buried alive in a landslide"
         }
     },
     {
         "event_id": "gen_death_bury_newleaf1",
-        "biome": ["any"],
+        "biome": ["plains", "mountainous"],
         "camp": [
             "any"
         ],
@@ -2639,7 +2585,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was buried alive in a mudslide.",
             "lead_death": "{VERB/m_c/were/was} buried alive in a mudslide"
         }
@@ -2666,7 +2612,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c slipped off the edge of a cliff.",
             "lead_death": "slipped off the edge of a cliff"
         }
@@ -2703,7 +2649,7 @@
             ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "reg_death": "m_c was pushed off a cliff by r_c."
         },
         "relationships": [
@@ -2767,7 +2713,7 @@
             ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "reg_death": "m_c was pushed off a cliff by r_c."
         },
         "relationships": [
@@ -2808,7 +2754,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [ "some_lives"],
         "weight": 20,
         "event_text": "m_c was killed by a falling boulder pushed from a cliff above {PRONOUN/m_c/object} by o_c warriors.",
@@ -2818,7 +2764,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was crushed by a falling boulder.",
             "lead_death": "{VERB/m_c/were/was} crushed by a falling boulder."
         }
@@ -2832,11 +2778,11 @@
         "season": [
             "any"
         ],
-        "tags": [ "all_lives", "no_body" ],
+        "tags": [ "no_body" ],
         "weight": 20,
         "event_text": "r_c, guarding camp, yowls a warning as they spot a circling shadow, right below m_c. r_c starts sprinting to m_c's position, but couldn't get there in time, not before m_c was carried high into the sky.",
         "m_c": {
-            "age": [ "any" ],
+            "age": [ "kitten", "adolescent" ],
             "status": [ "any" ],
             "not_skill": [
                 "RUNNER,2"
@@ -2848,9 +2794,8 @@
             "status": [ "any" ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
-            "reg_death": "m_c was grabbed by a hawk, never to be seen again.",
-            "lead_death": "{VERB/m_c/were/was} grabbed by a hawk, never to be seen again"
+            "cats": ["m_c"],
+            "reg_death": "m_c was grabbed by a hawk, never to be seen again."
         }
     },
     {
@@ -2877,7 +2822,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was taken by a hawk."
         }
     },
@@ -2906,7 +2851,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c failed to thrive."
         }
     },
@@ -2938,7 +2883,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c fell into the river and drowned."
         }
     },
@@ -2970,7 +2915,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c died when {PRONOUN/m_c/subject} snuck out of camp."
         }
     },
@@ -3002,7 +2947,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c died when {PRONOUN/m_c/subject} got into the herb stores and ate deathberries."
         }
     },
@@ -3028,7 +2973,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was killed by a snake."
         }
     },
@@ -3057,7 +3002,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c died of kittencough."
         }
     },
@@ -3086,7 +3031,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c died of whitecough."
         }
     },
@@ -3115,7 +3060,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c died of greencough."
         }
     },
@@ -3144,7 +3089,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was killed by sickness."
         }
     },
@@ -3180,7 +3125,7 @@
         },
         "history": {
             "cats": ["m_c", "r_c"],
-            "reg_death": "m_c died of kittencough."
+            "reg_death": "This cat died of kittencough."
         }
     },
     {
@@ -3215,7 +3160,7 @@
         },
         "history": {
             "cats": ["m_c", "r_c"],
-            "reg_death": "m_c died of whitecough."
+            "reg_death": "This cat died of whitecough."
         }
     },
     {
@@ -3250,7 +3195,7 @@
         },
         "history": {
             "cats": ["m_c", "r_c"],
-            "reg_death": "m_c died of greencough."
+            "reg_death": "This cat died of greencough."
         }
     },
     {
@@ -3283,7 +3228,7 @@
             ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "reg_death": "m_c was killed in battle training with r_c."
         },
         "relationships": [
@@ -3342,7 +3287,7 @@
             "status": [ "apprentice", "warrior", "deputy", "leader" ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "reg_death": "m_c ate deathberries and succumbed to the poison."
         },
         "relationships": [
@@ -3410,7 +3355,7 @@
             "status": [ "any" ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "reg_death": "m_c drowned in a stream while r_c watched."
         },
         "relationships": [
@@ -3472,7 +3417,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was killed when o_c warriors broke into camp."
         },
         "other_clan": {
@@ -3529,7 +3474,7 @@
             "status": [ "apprentice", "warrior", "deputy", "leader"]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "reg_death": "m_c was killed by a o_c warrior while trying to aid an injured Clanmate."
         },
         "relationships": [
@@ -3593,7 +3538,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c died of greencough."
         }
     },
@@ -3620,7 +3565,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c died while wandering the territory."
         }
     },
@@ -3647,7 +3592,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was killed by a fox.",
             "lead_death": "{VERB/m_c/were/was} killed by a fox"
         }
@@ -3675,7 +3620,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was killed by a badger.",
             "lead_death": "{VERB/m_c/were/was} killed by a badger"
         }
@@ -3703,7 +3648,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was killed by a dog.",
             "lead_death": "{VERB/m_c/were/was} killed by a dog"
         }
@@ -3734,7 +3679,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c died of whitecough.",
             "lead_death": "died of whitecough"
         }
@@ -3765,7 +3710,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c succumbed to illness.",
             "lead_death": "succumbed to illness"
         }
@@ -3796,7 +3741,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c died of whitecough.",
             "lead_death": "died of whitecough"
         }
@@ -3827,7 +3772,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c died of greencough.",
             "lead_death": "died of greencough"
         }
@@ -3841,7 +3786,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c suffered a heart attack due to the stress of the ongoing war.",
@@ -3857,7 +3802,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c died of a heart attack due to stress.",
             "lead_death": "died of a heart attack due to stress"
         }
@@ -3889,7 +3834,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "{VERB/m_c/were/was} struck by lightning"
         }
     },
@@ -3921,7 +3866,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "{VERB/m_c/were/was} mortally wounded by a fox"
         }
     },
@@ -3984,7 +3929,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "{VERB/m_c/were/was} mauled by a dog"
         }
     },
@@ -4016,7 +3961,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "{VERB/m_c/were/was} killed by a badger"
         }
     },
@@ -4048,7 +3993,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "fought a rogue"
         }
     },
@@ -4077,7 +4022,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "{VERB/m_c/were/was} bit by a venomous spider"
         }
     },
@@ -4106,7 +4051,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "{VERB/m_c/were/was} bit by a venomous snake"
         }
     },
@@ -4135,7 +4080,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "ate tainted fresh-kill"
         }
     },
@@ -4168,7 +4113,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "failed to interpret a warning from StarClan"
         }
     },
@@ -4218,7 +4163,7 @@
             "status": [ "any" ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "lead_death": "defended r_c from a dog"
         },
         "relationships": [
@@ -4297,7 +4242,7 @@
             "status": [ "any" ]
         },
         "history": {
-            "cats": ["m_c", "r_c" ],
+            "cats": ["m_c" ],
             "lead_death": "defended r_c from a badger"
         },
         "relationships": [
@@ -4451,7 +4396,7 @@
             "status": [ "any" ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "lead_death": "saved r_c from drowning"
         },
         "relationships": [
@@ -4525,7 +4470,7 @@
             "status": [ "any" ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "lead_death": "saved r_c from a monster"
         },
         "relationships": [
@@ -4601,7 +4546,7 @@
             "status": [ "any" ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "lead_death": "saved r_c from a snake"
         },
         "relationships": [
@@ -4679,7 +4624,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "defended the kits from o_c warriors"
         },
         "other_clan": {
@@ -4737,7 +4682,7 @@
             "status": [ "apprentice", "warrior", "medicine cat apprentice", "medicine cat", "deputy"]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "lead_death": "defended r_c from o_c warriors"
         },
         "relationships": [
@@ -4805,7 +4750,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "fought an apprentice from o_c"
         },
         "other_clan": {
@@ -4856,7 +4801,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "saved an apprentice from o_c"
         },
         "other_clan": {
@@ -4895,7 +4840,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "fought a warrior from o_c"
         },
         "other_clan": {
@@ -4946,7 +4891,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "saved a warrior from o_c"
         },
         "other_clan": {
@@ -4985,7 +4930,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "fought the o_c leader"
         },
         "other_clan": {
@@ -5036,7 +4981,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "saved the o_c leader"
         },
         "other_clan": {
@@ -5075,7 +5020,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "fought the o_c deputy"
         },
         "other_clan": {
@@ -5126,7 +5071,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "saved the o_c deputy"
         },
         "other_clan": {
@@ -5147,14 +5092,11 @@
             "any"
         ],
         "sub_type": [ "old_age" ],
-        "tags": [],
+        "tags": [ "some_lives" ],
         "weight": 20,
         "event_text": "m_c lost some lives to {PRONOUN/m_c/poss} old age.",
         "m_c": {
             "age": [
-                "young adult",
-                "adult",
-                "senior adult",
                 "senior"
             ],
             "status": [
@@ -5163,7 +5105,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "succumbed to old age"
         }
     },
@@ -5182,9 +5124,6 @@
         "event_text": "m_c's body just couldn't continue forward - {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} lost all of {PRONOUN/m_c/poss} remaining lives to old age.",
         "m_c": {
             "age": [
-                "young adult",
-                "adult",
-                "senior adult",
                 "senior"
             ],
             "status": [
@@ -5193,7 +5132,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "succumbed to old age"
         }
     },
@@ -5227,7 +5166,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "{VERB/m_c/were/was} brutally attacked by a rogue"
         }
     },
@@ -5261,7 +5200,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "{VERB/m_c/were/was} mauled by dogs"
         }
     },
@@ -5305,7 +5244,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "{VERB/m_c/were/was} killed in a fire trying to save {PRONOUN/m_c/poss} Clanmates"
         }
     },
@@ -5339,7 +5278,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "{VERB/m_c/were/was} brutally murdered by a warrior from o_c"
         },
         "other_clan": {
@@ -5379,7 +5318,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "{VERB/m_c/were/was} brutally murdered by the leader of o_c"
         },
         "other_clan": {
@@ -5419,7 +5358,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "{VERB/m_c/were/was} brutally murdered by the deputy of o_c"
         },
         "other_clan": {
@@ -5457,7 +5396,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "contracted greencough"
         }
     },
@@ -5490,7 +5429,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "contracted greencough"
         }
     },
@@ -5522,7 +5461,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "contracted whitecough"
         }
     },
@@ -5555,7 +5494,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "contracted whitecough"
         }
     },
@@ -5587,7 +5526,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "contracted yellowcough"
         }
     },
@@ -5620,7 +5559,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "contracted yellowcough"
         }
     },
@@ -5652,7 +5591,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "killed by infected wounds"
         }
     },
@@ -5673,7 +5612,6 @@
         "event_text": "m_c lost lives to old age, {PRONOUN/m_c/poss} body slowly becoming more and more frail.",
         "m_c": {
             "age": [
-                "senior adult",
                 "senior"
             ],
             "status": [
@@ -5682,7 +5620,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "died of old age"
         }
     },
@@ -5703,7 +5641,6 @@
         "event_text": "m_c collapses in the midst of camp, losing {PRONOUN/m_c/poss} remaining lives to old age.",
         "m_c": {
             "age": [
-                "senior adult",
                 "senior"
             ],
             "status": [
@@ -5712,7 +5649,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "died of old age"
         }
     },
@@ -5731,7 +5668,6 @@
         "event_text": "One day, the deputy finds m_c dead in the leader's den. Seems {PRONOUN/m_c/subject} lost a life to old age.",
         "m_c": {
             "age": [
-                "senior adult",
                 "senior"
             ],
             "status": [
@@ -5740,7 +5676,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "died of old age"
         }
     },
@@ -5761,7 +5697,6 @@
         "event_text": "One day, m_c is found dead in the leader's den, never to rise again. Seems {PRONOUN/m_c/subject} lost the rest of {PRONOUN/m_c/poss} lives to old age.",
         "m_c": {
             "age": [
-                "senior adult",
                 "senior"
             ],
             "status": [
@@ -5770,7 +5705,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "died of old age"
         }
     },
@@ -5791,7 +5726,6 @@
         "event_text": "Despite StarClan's efforts, m_c's body just couldn't continue. {PRONOUN/m_c/poss/CAP} remaining lives were taken by old age.",
         "m_c": {
             "age": [
-                "senior adult",
                 "senior"
             ],
             "status": [
@@ -5849,7 +5783,7 @@
             "status": [ "apprentice", "mediator apprentice", "medicine cat apprentice", "medicine cat", "mediator", "warrior", "deputy" ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "lead_death": "{VERB/m_c/were/was} pushed under a monster by r_c"
         },
         "relationships": [
@@ -5891,8 +5825,7 @@
             "any"
         ],
         "sub_type": [
-            "murder",
-            "murder_reveal"
+            "murder"
         ],
         "tags": [
             "all_lives"
@@ -5931,7 +5864,7 @@
             ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "lead_death": "{VERB/m_c/were/was} murdered by r_c"
         },
         "relationships": [
@@ -5959,7 +5892,7 @@
             "any"
         ],
         "sub_type": [ "murder" ],
-        "tags": [],
+        "tags": [ "some_lives" ],
         "weight": 20,
         "event_text": "m_c was murdered by r_c, intending to take {PRONOUN/m_c/poss} place, but r_c miscalculated how many lives m_c had left! m_c retaliated by killing r_c in self defense.",
         "m_c": {
@@ -5995,7 +5928,7 @@
             ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "reg_death": "m_c was killed by r_c in self-defense.",
             "lead_death": "{VERB/m_c/were/was} murdered by r_c in an attempt to usurp {PRONOUN/m_c/poss} position"
         },
@@ -6103,7 +6036,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "In the chaos of battle and the throes of a war, it's nearly impossible to tell friend from foe. Blinded by blood, r_c accidentally kills m_c. m_c lost one life.",
@@ -6142,8 +6075,8 @@
             ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
-            "reg_death": "m_c was accidentally attacked by m_c in battle.",
+            "cats": ["m_c"],
+            "reg_death": "m_c was accidentally attacked by r_c in battle.",
             "lead_death": "{VERB/m_c/were/was} accidentally attacked by r_c in the chaos of battle"
         }
     },
@@ -6164,9 +6097,6 @@
         "event_text": "m_c and r_c loved each other so much they could not be parted, even by death. c_n finds their bodies still wrapped around each other in the morning.",
         "m_c": {
             "age": [
-                "young adult",
-                "adult",
-                "senior adult",
                 "senior"
             ],
             "status": [
@@ -6196,7 +6126,7 @@
         "season": [
             "any"
         ],
-        "tags": [],
+        "tags": [ "some_lives" ],
         "weight": 20,
         "event_text": "m_c has always wondered where {PRONOUN/m_c/subject} came from. {PRONOUN/m_c/subject/CAP} {VERB/m_c/sneak/sneaks} out of camp, intending to find loners who might have some clues about {PRONOUN/m_c/poss} origins. Frantic with worry and confusion after finding m_c's empty nest in the morning, they launch a search. c_n finds m_c stumbling back to camp, pelt haggard and eyes haunted.",
         "m_c": {
@@ -6214,7 +6144,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "lead_death": "became a bit too curious"
         }
     },
@@ -6262,7 +6192,7 @@
             "status": [ "any" ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "lead_death": "defended r_c from o_c warriors"
         },
         "other_clan": {
@@ -6294,7 +6224,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c died in a training accident."
         }
     },
@@ -6327,7 +6257,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was killed by o_c warriors after accidentally trespassing."
         },
         "other_clan": {
@@ -6375,7 +6305,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was killed by o_c warriors after deliberately trespassing."
         },
         "other_clan": {
@@ -6408,7 +6338,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c died in a border skirmish against o_c."
         },
         "other_clan": {
@@ -6456,7 +6386,7 @@
         },
         "history": {
             "cats": ["m_c", "r_c"],
-            "reg_death": "m_c died in a border skirmish against o_c."
+            "reg_death": "This cat died in a border skirmish against o_c."
         },
         "other_clan": {
             "current_rep": [
@@ -6497,7 +6427,7 @@
             ]
         },
         "history": {
-            "cats": ["m_c", "r_c"],
+            "cats": ["m_c"],
             "reg_death": "m_c was killed in battle training with r_c."
         },
         "relationships": [

--- a/resources/dicts/events/death/general.json
+++ b/resources/dicts/events/death/general.json
@@ -1,115 +1,7 @@
 [
     {
-        "event_id": "gen_death_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "no_body"
-        ],
-        "weight": 20,
-        "event_text": "m_c was washed out to sea, never to be seen again.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "dies": true
-        },
-        "history": {
-            "reg_death": "m_c was washed out to sea."
-        }
-    },
-    {
-        "event_id": "gen_death_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was poisoned by a sea creature and died.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "dies": true
-        },
-        "history": {
-            "reg_death": "m_c was killed by a poisonous sea creature."
-        }
-    },
-    {
-        "event_id": "gen_death_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "shock",
-            "no_body"
-        ],
-        "weight": 20,
-        "event_text": "m_c was lost to the sea while trying to save r_c from drowning.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
-            "trait": [
-                "bold",
-                "ambitious",
-                "compassionate",
-                "daring",
-                "confident",
-                "fierce",
-                "loyal",
-                "loving",
-                "empathetic",
-                "responsible"
-            ],
-            "dies": true
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "injury": [
-            {
-                "cats": [
-                    "r_c"
-                ],
-                "injuries": [
-                    "water in their lungs"
-                ]
-            }
-        ],
-        "history": {
-            "reg_death": "m_c was lost to the sea while trying to save r_c."
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic",
-                    "trust",
-                    "respect",
-                    "dislike"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_heat_greenleaf1",
+        "biome": [ "forest", "beach", "plains" ],
         "camp": [
             "any"
         ],
@@ -122,82 +14,41 @@
         "weight": 20,
         "event_text": "m_c died from dehydration and heat stroke.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "any" ],
+            "status": [ "any"],
             "dies": true
         },
         "history": {
-            "reg_death": "m_c died of dehydration and heat stroke."
+            "cats": "m_c",
+            "reg_death": "m_c died of dehydration and heat stroke.",
+            "lead_death": "died of dehydration and heat stroke"
         }
     },
     {
-        "event_id": "gen_death_",
-        "camp": [
-            "camp3"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "no_body"
-        ],
-        "weight": 20,
-        "event_text": "m_c found {PRONOUN/m_c/self} staring at an odd shadow in the sea. One distracted paw slipped and {PRONOUN/m_c/subject} fell into the waves where something large and unseen tangled around {PRONOUN/m_c/object}, dragging {PRONOUN/m_c/object} into the abyss. ",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "dies": true
-        },
-        "history": {
-            "reg_death": "m_c was taken by a mysterious sea creature."
-        }
-    },
-    {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_murder_any1",
+        "biome": [ "any" ],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
-        "weight": 20,
-        "event_text": "m_c drowned after being pushed out to sea by o_c warriors.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "dies": true
-        },
-        "history": {
-            "reg_death": "m_c was pushed out to sea by enemy warriors."
-        }
-    },
-    {
-        "event_id": "gen_death_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "murder"
-        ],
+        "sub_type": [ "murder" ],
+        "tags": [],
         "weight": 20,
         "event_text": "m_c was murdered. The culprit is unknown.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "any" ],
+            "status": [ "kitten", "apprentice", "medicine cat apprentice", "medicine cat", "mediator", "mediator apprentice", "deputy", "warrior", "elder" ],
             "relationship_status": [],
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "any" ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c was secretly murdered by r_c."
         },
         "relationships": [
@@ -209,41 +60,52 @@
                     "m_c"
                 ],
                 "values": [
-                    "dislike",
                     "platonic"
                 ],
-                "amount": -5
+                "amount": -15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": 15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_murder_any2",
+        "biome": [ "any" ],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "murder",
-            "revealed"
-        ],
+        "sub_type": [ "murder" ],
+        "tags": [],
         "weight": 20,
         "event_text": "m_c was murdered. r_c stands over {PRONOUN/m_c/object}, blood dripping from {PRONOUN/r_c/poss} pelt.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "any" ],
+            "status": [ "kitten", "apprentice", "medicine cat apprentice", "medicine cat", "mediator", "mediator apprentice", "deputy", "warrior", "elder" ],
             "relationship_status": [],
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "any" ],
             "skill": [
                 "FIGHTER,2"
             ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c was murdered by r_c."
         },
         "relationships": [
@@ -255,30 +117,43 @@
                     "m_c"
                 ],
                 "values": [
-                    "dislike",
                     "platonic"
                 ],
-                "amount": -5
+                "amount": -15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": 15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_murder_any3",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
+        "sub_type":  [
             "murder",
-            "revealed"
+            "murder_reveal"
         ],
+        "tags": [],
         "weight": 20,
         "event_text": "m_c was murdered by r_c in cold blood.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "any" ],
+            "status": ["kitten", "apprentice", "medicine cat apprentice", "medicine cat", "mediator", "mediator apprentice", "deputy", "warrior", "elder"],
             "relationship_status": [],
             "not_skill": [
                 "FIGHTER,2"
@@ -286,13 +161,14 @@
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "any" ],
             "skill": [
                 "FIGHTER,2"
             ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c was murdered by r_c."
         },
         "relationships": [
@@ -304,44 +180,55 @@
                     "m_c"
                 ],
                 "values": [
-                    "dislike",
                     "platonic"
                 ],
-                "amount": -5
+                "amount": -15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": 15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_murder_any4",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "murder"
-        ],
+        "sub_type": [ "murder" ],
+        "tags": [],
         "weight": 20,
         "event_text": "m_c was murdered by r_c in cold blood. r_c has made the death look accidental.",
         "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
+            "age": [ "any" ],
+            "status": ["kitten", "apprentice", "medicine cat apprentice", "medicine cat", "mediator", "mediator apprentice", "deputy", "warrior", "elder"],
             "not_skill": [
                 "FIGHTER,2"
             ],
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "any" ],
             "skill": [
                 "FIGHTER,2",
                 "CLEVER,3"
             ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c was secretly murdered by r_c, who made the death look accidental."
         },
         "relationships": [
@@ -353,40 +240,51 @@
                     "m_c"
                 ],
                 "values": [
-                    "dislike",
                     "platonic"
                 ],
-                "amount": -5
+                "amount": -15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": 15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_murder_anymed1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "murder",
-            "revealed"
-        ],
+        "sub_type": [ "murder" ],
+        "tags": [],
         "weight": 20,
         "event_text": "r_c killed m_c by feeding {PRONOUN/m_c/object} deathberries.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "any" ],
+            "status": ["kitten", "apprentice", "medicine cat apprentice", "medicine cat", "mediator", "mediator apprentice", "deputy", "warrior", "elder" ],
             "not_skill": [
                 "CLEVER,2"
             ],
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "any" ],
+            "status": [ "medicine cat apprentice", "medicine cat" ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c was murdered by r_c, who fed {PRONOUN/m_c/object} deathberries."
         },
         "relationships": [
@@ -398,41 +296,52 @@
                     "m_c"
                 ],
                 "values": [
-                    "dislike",
+                    "dislike"
+                ],
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
                     "platonic",
                     "comfort"
                 ],
-                "amount": -5
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_murder_anymed2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "murder",
-            "revealed"
-        ],
+        "sub_type": [ "murder" ],
+        "tags": [],
         "weight": 20,
         "event_text": "r_c killed m_c by feeding {PRONOUN/m_c/object} foxglove seeds.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "any" ],
+            "status": ["kitten", "apprentice", "medicine cat apprentice", "medicine cat", "mediator", "mediator apprentice", "deputy", "warrior", "elder"],
             "not_skill": [
                 "CLEVER,2"
             ],
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "any" ],
+            "status": [ "medicine cat apprentice", "medicine cat" ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c was murdered by r_c, who fed {PRONOUN/m_c/object} foxglove seeds."
         },
         "relationships": [
@@ -444,41 +353,52 @@
                     "m_c"
                 ],
                 "values": [
-                    "dislike",
+                    "dislike"
+                ],
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
                     "platonic",
                     "comfort"
                 ],
-                "amount": -5
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_murder_anymed3",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "murder",
-            "revealed"
-        ],
+        "sub_type": [ "murder" ],
+        "tags": [],
         "weight": 20,
         "event_text": "r_c killed m_c by feeding {PRONOUN/m_c/object} nightshade berries.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "any" ],
+            "status": [ "kitten", "apprentice", "medicine cat apprentice", "medicine cat", "mediator", "mediator apprentice", "deputy", "warrior", "elder" ],
             "not_skill": [
                 "CLEVER,2"
             ],
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "any" ],
+            "status": [ "medicine cat apprentice", "medicine cat" ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c was murdered by r_c, who fed {PRONOUN/m_c/object} nightshade berries."
         },
         "relationships": [
@@ -490,41 +410,52 @@
                     "m_c"
                 ],
                 "values": [
-                    "dislike",
+                    "dislike"
+                ],
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
                     "platonic",
                     "comfort"
                 ],
-                "amount": -5
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_murder_anymed4",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "murder",
-            "revealed"
-        ],
+        "sub_type": [ "murder" ],
+        "tags": [],
         "weight": 20,
         "event_text": "r_c killed m_c by feeding {PRONOUN/m_c/object} water hemlock.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "any" ],
+            "status": [ "kitten", "apprentice", "medicine cat apprentice", "medicine cat", "mediator", "mediator apprentice", "deputy", "warrior", "elder"],
             "not_skill": [
                 "CLEVER,2"
             ],
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "any" ],
+            "status": [ "medicine cat apprentice", "medicine cat" ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c was murdered by r_c, who fed {PRONOUN/m_c/object} water hemlock."
         },
         "relationships": [
@@ -536,41 +467,52 @@
                     "m_c"
                 ],
                 "values": [
-                    "dislike",
+                    "dislike"
+                ],
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
                     "platonic",
                     "comfort"
                 ],
-                "amount": -5
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_murder_anymed5",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "murder",
-            "revealed"
-        ],
+        "sub_type": [ "murder" ],
+        "tags": [],
         "weight": 20,
         "event_text": "r_c killed m_c by consciously giving {PRONOUN/m_c/object} the wrong herbs.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "any" ],
+            "status": [ "kitten", "apprentice", "medicine cat apprentice", "medicine cat", "mediator", "mediator apprentice", "deputy", "warrior", "elder"],
             "not_skill": [
                 "CLEVER,2"
             ],
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "any" ],
+            "status": [ "medicine cat apprentice", "medicine cat" ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c was murdered by r_c, who purposefully fed {PRONOUN/m_c/object} the wrong herbs."
         },
         "relationships": [
@@ -582,16 +524,28 @@
                     "m_c"
                 ],
                 "values": [
-                    "dislike",
+                    "dislike"
+                ],
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
                     "platonic",
                     "comfort"
                 ],
-                "amount": -5
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_fox_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -602,8 +556,8 @@
         "weight": 20,
         "event_text": "m_c was found dead near a fox den.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult"],
+            "status": [ "any" ],
             "not_skill": [
                 "FIGHTER,2"
             ],
@@ -619,11 +573,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was killed by a fox."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_snake_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -632,18 +588,20 @@
         ],
         "tags": [],
         "weight": 20,
-        "event_text": "m_c was bitten by a snake, and succumbed to the venom.",
+        "event_text": "m_c was bitten by a snake and succumbed to the venom.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": ["adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
-            "reg_death": "m_c was killed by a snake."
+            "cats": "m_c",
+            "reg_death": "m_c was killed by a snake.",
+            "lead_death": "{VERB/m_c/were/was} bitten by a snake"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_snake_any2",
         "camp": [
             "any"
         ],
@@ -654,10 +612,10 @@
             "clan_kits"
         ],
         "weight": 20,
-        "event_text": "m_c saved a kit from a snake, but was bitten in the process. The venom killed {PRONOUN/m_c/object}.",
+        "event_text": "m_c saved r_c from a snake but was bitten in the process. The venom killed {PRONOUN/m_c/object}.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "any" ],
             "trait": [
                 "bold",
                 "ambitious",
@@ -674,12 +632,19 @@
             ],
             "dies": true
         },
+        "r_c": {
+            "age": [ "newborn", "kitten" ],
+            "status": [ "any" ]
+        },
         "history": {
-            "reg_death": "m_c was killed by a snake, while saving a kit."
+            "cats": "m_c",
+            "reg_death": "m_c was killed by a snake while saving a kit.",
+            "lead_death": "died saving a kit from a snake"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_missing_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -688,18 +653,20 @@
         ],
         "tags": [],
         "weight": 20,
-        "event_text": "m_c went missing, and was found dead out in the territory.",
+        "event_text": "m_c went missing and was found dead out in the territory.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "apprentice", "medicine cat apprentice", "medicine cat", "mediator", "mediator apprentice", "deputy", "warrior", "elder" ],
             "dies": true
         },
         "history": {
-            "reg_death": "m_c went missing, and was found dead."
+            "cats": "m_c",
+            "reg_death": "m_c went missing and was found dead."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_border_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -710,14 +677,15 @@
         "weight": 20,
         "event_text": "m_c was found dead near the o_c border.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "any" ],
+            "status": [ "kitten", "apprentice", "medicine cat apprentice", "medicine cat", "mediator", "mediator apprentice", "deputy", "warrior", "elder" ],
             "not_skill": [
                 "FIGHTER,2"
             ],
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was found dead near the o_c border."
         },
         "other_clan": {
@@ -726,7 +694,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_siege_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -737,26 +706,21 @@
         "weight": 20,
         "event_text": "o_c attempted to break into the camp. m_c and r_c are left cold on the ground in the aftermath.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "any" ],
             "relationship_status": [],
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "This cat died when o_c tried to break into camp.",
             "lead_death": "tried to defend the Clan from o_c"
         },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ],
         "other_clan": {
             "current_rep": [
                 "hostile"
@@ -765,7 +729,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_siege_any2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -776,8 +741,8 @@
         "weight": 20,
         "event_text": "o_c attempted to break into the camp. m_c died defending the nursery, r_c huddled beneath {PRONOUN/m_c/poss} cooling body.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "any" ],
             "relationship_status": [],
             "trait": [
                 "vengeful",
@@ -798,17 +763,13 @@
             "age": [
                 "kitten"
             ],
-            "status": []
+            "status": [ "any" ]
         },
         "history": {
-            "reg_death": "m_c died defending r_c from o_c warriors."
+            "cats": ["m_c", "r_c"],
+            "reg_death": "m_c died defending r_c from o_c warriors.",
+            "lead_death": "died defending the nursery"
         },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ],
         "other_clan": {
             "current_rep": [
                 "hostile"
@@ -817,7 +778,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_fire_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -828,8 +790,8 @@
         "weight": 20,
         "event_text": "m_c was burnt alive while trying to save r_c from a fire.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "any" ],
             "relationship_status": [],
             "trait": [
                 "bold",
@@ -846,11 +808,13 @@
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "any" ],
+            "status": [ "any" ]
         },
         "history": {
-            "reg_death": "m_c was killed in a fire while trying to save r_c."
+            "cats": ["m_c", "r_c"],
+            "reg_death": "m_c was killed in a fire while trying to save r_c.",
+            "lead_death": "{VERB/m_c/were/was} burnt alive saving r_c"
         },
         "relationships": [
             {
@@ -863,15 +827,27 @@
                 "values": [
                     "platonic",
                     "trust",
-                    "respect",
+                    "respect"
+                ],
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
                     "dislike"
                 ],
-                "amount": -5
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_greencough_leafbare1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -884,16 +860,19 @@
         "weight": 20,
         "event_text": "m_c died after catching greencough.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "any" ],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
-            "reg_death": "m_c died of greencough."
+            "cats": "m_c",
+            "reg_death": "m_c died of greencough.",
+            "lead_death": "died of greencough"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_infection_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -906,16 +885,19 @@
         "weight": 20,
         "event_text": "m_c died from infected wounds.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "any" ],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
-            "reg_death": "m_c died from infected wounds."
+            "cats": "m_c",
+            "reg_death": "m_c died from infected wounds.",
+            "lead_death": "died from infected wounds"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_badprey_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -928,29 +910,25 @@
         "weight": 20,
         "event_text": "m_c and r_c die from eating tainted prey.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "any" ],
+            "status": [ "any" ],
             "relationship_status": [],
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [ "any" ],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
+            "cats": [ "m_c", "r_c" ],
             "reg_death": "m_c died from eating tainted prey.",
             "lead_death": "ate tainted prey"
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
+        }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_drown_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -959,10 +937,10 @@
         ],
         "tags": [],
         "weight": 20,
-        "event_text": "m_c fell into the river and r_c drowned alongside m_c while trying to rescue {PRONOUN/m_c/object}.",
+        "event_text": "m_c fell into the river, and r_c drowned alongside m_c while trying to rescue {PRONOUN/m_c/object}.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "any" ],
+            "status": [ "any" ],
             "relationship_status": [],
             "dies": true
         },
@@ -972,7 +950,7 @@
                 "adult",
                 "senior adult"
             ],
-            "status": [],
+            "status": [ "any" ],
             "trait": [
                 "bold",
                 "ambitious",
@@ -988,18 +966,14 @@
             "dies": true
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c drowned alongside a Clanmate.",
             "lead_death": "drowned alongside a Clanmate"
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
+        }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_rogue_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -1010,9 +984,11 @@
         "weight": 20,
         "event_text": "m_c and r_c are killed by a gang of rogues.",
         "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
+            "age": [
+            "young adult",
+            "adult",
+            "senior adult" ],
+            "status": [ "any" ],
             "dies": true
         },
         "r_c": {
@@ -1021,22 +997,18 @@
                 "adult",
                 "senior adult"
             ],
-            "status": [],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
+            "cats": [ "m_c", "r_c" ],
             "reg_death": "m_c was killed by a gang of rogues.",
             "lead_death": "{VERB/m_c/were/was} killed by a gang of rogues"
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
+        }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_greencough_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -1049,29 +1021,24 @@
         "weight": 20,
         "event_text": "r_c and m_c die of greencough.",
         "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
+            "age": [ "any" ],
+            "status": [ "any" ],
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [ "any" ],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c died of greencough.",
             "lead_death": "died of greencough"
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
+        }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_yellowcough_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -1084,29 +1051,24 @@
         "weight": 20,
         "event_text": "r_c and m_c die of yellowcough.",
         "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
+            "age": [ "any" ],
+            "status": [ "any" ],
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [ "any" ],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c died of yellowcough.",
             "lead_death": "died of yellowcough"
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
+        }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -1119,29 +1081,24 @@
         "weight": 20,
         "event_text": "A bad case of greencough strikes the Clan, taking r_c and m_c's lives.",
         "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
+            "age": [ "any" ],
+            "status": [ "any" ],
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [ "any" ],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c died of greencough.",
             "lead_death": "died of greencough"
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
+        }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_curious_any1",
+        "biome": ["any"],
         "camp": [
             "Any"
         ],
@@ -1152,9 +1109,8 @@
         "weight": 20,
         "event_text": "m_c has always wondered where {PRONOUN/m_c/subject} came from. {PRONOUN/m_c/subject/CAP} {VERB/m_c/sneak/sneaks} out of camp, intending to find loners who might have some clues about {PRONOUN/m_c/poss} origins. Frantic with worry and confusion after finding m_c's empty nest in the morning, c_n launches a search. They find {PRONOUN/m_c/poss} cooling body after a long search and wonders why {PRONOUN/m_c/subject} decided to leave the safety of c_n, and what killed {PRONOUN/m_c/object}.",
         "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
+            "age": [ "adolescent", "young adult"],
+            "status": [ "apprentice", "mediator apprentice", "medicine cat apprentice", "warrior", "mediator", "medicine cat", "deputy" ],
             "backstory": [
                 "abandoned1",
                 "abandoned2",
@@ -1162,377 +1118,466 @@
             ],
             "dies": true
         },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
         "history": {
-            "reg_death": "Curiosity killed this cat.",
-            "lead_death": "lost a life because of curiosity."
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
+            "cats": "m_c",
+            "reg_death": "Curiosity killed this cat."
+        }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_war_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "m_c sacrificed {PRONOUN/m_c/self} for r_c in a battle with o_c.",
         "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "apprentice", "warrior", "deputy", "leader" ],
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "apprentice", "warrior", "deputy", "leader" ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c sacrificed {PRONOUN/m_c/self} for r_c in battle.",
             "lead_death": "sacrificed {PRONOUN/m_c/self} for r_c in battle."
         },
         "relationships": [
             {
-                "values": [],
-                "amount": 5
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "platonic",
+                    "trust",
+                    "respect"
+                ],
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_war_any2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "m_c threw {PRONOUN/m_c/self} in front of an oncoming attack meant for r_c, taking the deadly blow instead.",
         "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "apprentice", "warrior", "deputy", "leader" ],
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "apprentice", "warrior", "deputy", "leader" ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c sacrificed {PRONOUN/m_c/self} for r_c in battle.",
             "lead_death": "sacrificed {PRONOUN/m_c/self} for r_c in battle."
         },
         "relationships": [
             {
-                "values": [],
-                "amount": 5
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "platonic",
+                    "trust",
+                    "respect"
+                ],
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_war_any3",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "m_c intentionally stayed behind and fought a losing battle to give r_c time to escape.",
         "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "apprentice", "warrior", "deputy", "leader" ],
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "apprentice", "warrior", "deputy", "leader" ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c sacrificed {PRONOUN/m_c/self} for r_c in battle.",
             "lead_death": "sacrificed {PRONOUN/m_c/self} for r_c in battle."
         },
         "relationships": [
             {
-                "values": [],
-                "amount": 5
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "platonic",
+                    "trust",
+                    "respect"
+                ],
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_war_any4",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "When traveling together near the border of c_n territory, m_c used {PRONOUN/m_c/poss} own body to shield r_c from a surprise o_c ambush, even though it meant certain death.",
         "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "apprentice", "warrior", "deputy", "leader" ],
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "any" ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c sacrificed {PRONOUN/m_c/self} for r_c in an ambush.",
             "lead_death": "sacrificed {PRONOUN/m_c/self} for r_c in an ambush."
         },
         "relationships": [
             {
-                "values": [],
-                "amount": 5
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "platonic",
+                    "trust",
+                    "respect"
+                ],
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_war_any5",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "m_c sacrificed {PRONOUN/m_c/self} by taking on the role of a messenger, delivering important information that could save {PRONOUN/m_c/poss} Clan. {PRONOUN/m_c/subject/CAP} {VERB/m_c/were/was} killed while investigating enemy territory.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "apprentice", "warrior" ],
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was killed investigating enemy territory.",
             "lead_death": "{VERB/m_c/were/was} killed investigating enemy territory."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_war_multi1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
-            "any"
+            "leaf-fall",
+            "newleaf",
+            "greenleaf"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "m_c drowned in a river while trying to escape from a sudden o_c attack.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": ["apprentice", "warrior", "deputy", "leader"],
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c drowned in a river attempting to escape an enemy attack.",
             "lead_death": "drowned in a river attempting to escape an enemy attack."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_war_any7",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [ "some_lives" ],
         "weight": 20,
         "event_text": "m_c fell into a pit trap set by o_c's warriors.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c fell into a pit trap set by an enemy Clan.",
             "lead_death": "fell into a pit trap set by an enemy Clan."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_war_any8",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [ "some_lives" ],
         "weight": 20,
         "event_text": "m_c was hit by a monster while escaping across a Thunderpath from o_c warriors.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "apprentice", "warrior", "deputy", "leader" ],
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was hit by a monster.",
             "lead_death": "{VERB/m_c/were/was} hit by a monster."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_age_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "old_age"
-        ],
+        "sub_type": [ "old_age" ],
+        "tags": [ ],
         "weight": 20,
-        "event_text": "m_c wandered out into the territory, and was later found dead, a peaceful expression on {PRONOUN/m_c/poss} face.",
+        "event_text": "m_c wandered out into the territory and was later found dead, a peaceful expression on {PRONOUN/m_c/poss} face.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "senior adult", "senior" ],
+            "status": [ "warrior", "medicine cat", "mediator", "elder" ],
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c died of old age."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_age_any2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
+        "sub_type": [
             "old_age"
         ],
+        "tags": [],
         "weight": 20,
-        "event_text": "m_c was found stiff and curled up in {PRONOUN/m_c/poss} nest.  It seems {PRONOUN/m_c/subject} died in {PRONOUN/m_c/poss} sleep.",
+        "event_text": "m_c was found stiff and curled up in {PRONOUN/m_c/poss} nest. It seems {PRONOUN/m_c/subject} died in {PRONOUN/m_c/poss} sleep.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "senior adult", "senior" ],
+            "status": [ "warrior", "medicine cat", "mediator", "elder" ],
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c died of old age."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_age_any3",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
+        "sub_type": [
             "old_age"
         ],
+        "tags": [],
         "weight": 20,
         "event_text": "m_c faded more and more as the days went by, until one day, {PRONOUN/m_c/subject} {VERB/m_c/were/was} found dead in {PRONOUN/m_c/poss} nest.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "senior adult", "senior" ],
+            "status": [ "warrior", "medicine cat", "mediator", "elder" ],
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c died of old age."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_age_any4",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
+        "sub_type": [
             "old_age"
         ],
+        "tags": [],
         "weight": 20,
         "event_text": "m_c is suddenly struck by a sharp pain in {PRONOUN/m_c/poss} chest. {PRONOUN/m_c/subject/CAP} {VERB/m_c/are/is} found later that day, cold.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "senior adult", "senior" ],
+            "status": [ "warrior", "medicine cat", "mediator", "elder" ],
             "dies": true
         },
         "history": {
+            "cats": ["m_c"],
             "reg_death": "m_c died of a heart attack."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_age_any5",
+        "biome": ["any"],
         "camp": [
-            "Any"
+            "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "old_age",
-            "all_lives"
-        ],
+        "sub_type": [ "old_age" ],
+        "tags": [ "all_lives" ],
         "weight": 20,
         "event_text": "m_c and r_c loved each other so much they could not be parted, even by death. c_n finds their bodies still wrapped around each other in the morning.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "senior adult", "senior" ],
+            "status": [ "any" ],
             "relationship_status": [
                 "mates"
             ],
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [ "senior adult", "senior" ],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "This cat died from old age life.",
             "lead_death": "lost all remaining lives from old age."
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
+        }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_predator_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -1541,31 +1586,30 @@
         ],
         "tags": [],
         "weight": 20,
-        "event_text": "m_c couldn't miss today! Such a bright day out, a perfect day to go for a walk. That was until m_c detected another scent, a strong one, and a foul one. {PRONOUN/m_c/subject/CAP} scrambled away from the area, but not before abnormally long claws slashed across their face.",
+        "event_text": "m_c couldn't miss today! Such a bright day, perfect for a walk. That was until m_c detected another scent, a strong one, and a foul one. {PRONOUN/m_c/subject/CAP} scrambled away from the area, but not before abnormally long claws slashed across their face.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was killed by an unknown predator."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_murder_anydep1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "murder",
-            "revealed",
-            "jealousy"
-        ],
+        "sub_type": [ "murder"],
+        "tags": [ ],
         "weight": 20,
-        "event_text": "m_c was murdered by r_c in cold blood, with the hope of taking {PRONOUN/m_c/poss} place.",
+        "event_text": "m_c was murdered by r_c in cold blood in the hope of taking {PRONOUN/m_c/poss} place.",
         "m_c": {
             "age": [
                 "young adult",
@@ -1575,15 +1619,14 @@
             "status": [
                 "deputy"
             ],
-            "relationship_status": [],
             "not_skill": [
                 "FIGHTER,2"
             ],
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [ "any" ],
+            "status": [ "warrior" ],
             "skill": [
                 "FIGHTER,2"
             ],
@@ -1598,6 +1641,7 @@
             ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c was murdered by r_c."
         },
         "relationships": [
@@ -1609,26 +1653,37 @@
                     "m_c"
                 ],
                 "values": [
-                    "dislike",
-                    "platonic"
+                    "dislike"
                 ],
-                "amount": -5
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "platonic",
+                    "trust",
+                    "comfort"
+                ],
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_murder_anydep2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "murder",
-            "revealed",
-            "jealousy"
-        ],
+        "sub_type": [ "murder" ],
+        "tags": [],
         "weight": 20,
         "event_text": "m_c was murdered by r_c in cold blood. r_c staged the death as an accident, and hopes to take {PRONOUN/m_c/poss} place.",
         "m_c": {
@@ -1640,15 +1695,14 @@
             "status": [
                 "deputy"
             ],
-            "relationship_status": [],
             "not_skill": [
                 "FIGHTER,2"
             ],
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [ "any" ],
+            "status": [ "warrior" ],
             "skill": [
                 "CLEVER,2"
             ],
@@ -1662,6 +1716,7 @@
             ]
         },
         "history": {
+            "cats": [ "m_c", "r_c" ],
             "reg_death": "m_c was secretly murdered by r_c."
         },
         "relationships": [
@@ -1673,28 +1728,39 @@
                     "m_c"
                 ],
                 "values": [
-                    "dislike",
-                    "platonic"
+                    "dislike"
                 ],
-                "amount": -5
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "platonic",
+                    "trust",
+                    "comfort"
+                ],
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_murder_any5",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "murder",
-            "revealed",
-            "jealousy"
-        ],
+        "sub_type": [ "murder" ],
+        "tags": [ "all_lives" ],
         "weight": 20,
-        "event_text": "A yowl took m_c by surprise as {PRONOUN/m_c/subject} {VERB/m_c/were/was} patrolling the territory. r_c suddenly crashed into view, meowing about how m_c had to come and see. m_c followed the distressed warrior to a small ravine. {PRONOUN/m_c/subject/CAP} peered over the edge, and noted the sharp rocks at the bottom. Suddenly, {PRONOUN/m_c/subject} felt a sharp shove from behind, letting out a yowl of surprise that was cut short as {PRONOUN/m_c/subject} landed on the rocks.",
+        "event_text": "A yowl took m_c by surprise as {PRONOUN/m_c/subject} {VERB/m_c/were/was} patrolling the territory. r_c suddenly crashed into view, meowing about how m_c had to come and see. m_c followed the distressed warrior to a small ravine. {PRONOUN/m_c/subject/CAP} peered over the edge and noted the sharp rocks at the bottom. Suddenly, {PRONOUN/m_c/subject} felt a sharp shove from behind, letting out a yowl of surprise that was cut short as {PRONOUN/m_c/subject} landed on the rocks.",
         "m_c": {
             "age": [
                 "young adult",
@@ -1702,16 +1768,18 @@
                 "senior adult"
             ],
             "status": [
-                "deputy"
+                "deputy", "leader"
             ],
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "any" ],
+            "status": [ "warrior" ]
         },
         "history": {
-            "reg_death": "m_c {VERB/m_c/were/was} pushed into a ravine by r_c."
+            "cats": ["m_c", "r_c"],
+            "reg_death": "m_c {VERB/m_c/were/was} pushed into a ravine by r_c.",
+            "lead_death": "{VERB/were/was} pushed into a ravine by r_c"
         },
         "relationships": [
             {
@@ -1722,37 +1790,29 @@
                     "m_c"
                 ],
                 "values": [
-                    "platonic"
+                    "dislike"
                 ],
-                "amount": -5
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "platonic",
+                    "trust",
+                    "comfort"
+                ],
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "war"
-        ],
-        "weight": 20,
-        "event_text": "m_c was killed by a falling branch during a battle in a heavily wooded area of the forest.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "dies": true
-        },
-        "history": {
-            "reg_death": "m_c was squished by a falling branch.",
-            "lead_death": "was squished by a falling branch."
-        }
-    },
-    {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_murder_multiice1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -1760,16 +1820,13 @@
             "newleaf",
             "leaf-bare"
         ],
-        "tags": [
-            "murder",
-            "revealed"
-        ],
+        "sub_type": [ "murder" ],
+        "tags": [],
         "weight": 20,
         "event_text": "m_c agreed to venture with r_c out onto a frozen pond. m_c went first while r_c hung back. m_c slid around playfully, taunting the other cat to chase {PRONOUN/m_c/object}. {PRONOUN/m_c/subject/CAP} {VERB/m_c/were/was} about to launch another teasing remark when the ice cracked below {PRONOUN/m_c/poss} paws. r_c lingered to make sure {PRONOUN/m_c/subject} didn't surface before running back to camp with a yowl.",
         "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status":  ["apprentice", "mediator apprentice", "medicine cat apprentice", "warrior", "medicine cat", "mediator", "deputy"],
             "not_skill": [
                 "PROPHET,3",
                 "OMEN,3",
@@ -1785,10 +1842,11 @@
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "any" ]
         },
         "history": {
+            "cats": ["m_c", "r_c" ],
             "reg_death": "m_c was lured onto thin ice by r_c, resulting in {PRONOUN/m_c/poss} death."
         },
         "relationships": [
@@ -1800,15 +1858,29 @@
                     "m_c"
                 ],
                 "values": [
-                    "dislike",
-                    "platonic"
+                    "dislike"
                 ],
-                "amount": -5
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "platonic",
+                    "trust",
+                    "comfort"
+                ],
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_drown_multi1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -1816,13 +1888,12 @@
             "newleaf",
             "leaf-bare"
         ],
-        "tags": [],
+        "tags": [ "some_lives" ],
         "weight": 20,
-        "event_text": "m_c and r_c talked each other into walking onto the ice of the frozen pond that lay not far from camp. It was a dare at first, but when m_c didn't immediately fall in, r_c joined {PRONOUN/m_c/object}. The two cats playfully slipped around for a bit before the minute cracks reached their ears. By then, it was too late to move.",
+        "event_text": "m_c and r_c talked each other into walking onto the ice of the frozen pond that lay not far from camp. It was a dare at first, but when m_c didn't immediately fall in, r_c joined {PRONOUN/m_c/object}. The two cats playfully slipped around for a bit before the faint cracks reached their ears. By then, it was too late to move.",
         "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "any" ],
             "not_skill": [
                 "PROPHET,3",
                 "OMEN,3",
@@ -1838,8 +1909,8 @@
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "any" ],
             "not_skill": [
                 "PROPHET,3",
                 "OMEN,3",
@@ -1855,46 +1926,14 @@
             "dies": true
         },
         "history": {
-            "reg_death": "m_c and r_c went to play on the ice of a frozen pond, not knowing it was too thin."
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_death_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was found dead underneath an oak tree with dog scent wreathing around them, after saying they were going to the dirtplace and not coming back.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "not_skill": [
-                "CLIMBER,2"
-            ],
-            "trait": [
-                "nervous",
-                "daring",
-                "ambitious",
-                "oblivious"
-            ],
-            "dies": true
-        },
-        "history": {
-            "reg_death": "m_c fell out of a tree while trying to escape from a dog."
+            "cats": [ "m_c", "r_c" ],
+            "reg_death": "m_c and r_c went to play on the ice of a frozen pond, not knowing it was too thin.",
+            "lead_death": "fell through thin ice and drowned"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_sinkhole_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -1907,56 +1946,64 @@
         "weight": 20,
         "event_text": "m_c fell into a sinkhole and was never seen again.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": ["apprentice", "mediator apprentice", "medicine cat apprentice", "warrior", "medicine cat", "mediator", "deputy"],
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c fell into a sinkhole."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_bury_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [],
+        "tags": [ "all_lives" ],
         "weight": 20,
         "event_text": "m_c fell into a hidden burrow and was buried alive.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
-            "reg_death": "m_c fell into a hidden burrow."
+            "cats": "m_c",
+            "reg_death": "m_c fell into a hidden burrow.",
+            "lead_death": "{VERB/m_c/were/was buried alive in a hidden burrow"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_bury_any2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [],
+        "tags": [ "all_lives" ],
         "weight": 20,
         "event_text": "m_c was buried alive when a burrow collapsed on {PRONOUN/m_c/object}.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
-            "reg_death": "m_c was buried alive when a burrow collapsed."
+            "cats": "m_c",
+            "reg_death": "m_c was buried alive when a burrow collapsed.",
+            "lead_death": "{VERB/m_c/were/was} buried alive in a hidden burrow"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_heat_greenleaf2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -1969,16 +2016,18 @@
         "weight": 20,
         "event_text": "m_c died from dehydration and heat stroke.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "kitten" ],
+            "status": [ "kitten" ],
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c died of dehydration and heat stroke."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_freeze_leafbare1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -1989,16 +2038,18 @@
         "weight": 20,
         "event_text": "m_c froze to death during a harsh snowstorm.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "kitten" ],
+            "status": [ "kitten" ],
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c froze to death."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_freeze_leafbare2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -2009,59 +2060,64 @@
         "weight": 20,
         "event_text": "m_c was found dead and cold in the snow.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "kitten" ],
+            "status": [ "kitten" ],
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c froze to death."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_drown_leafbare1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "leaf-bare"
         ],
-        "tags": [],
+        "tags": [ "some_lives" ],
         "weight": 20,
         "event_text": "m_c was walking on the ice, when it cracked and {PRONOUN/m_c/subject} fell in.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
-            "reg_death": "m_c froze to death after falling through ice."
+            "cats": "m_c",
+            "reg_death": "m_c froze to death after falling through ice.",
+            "lead_death": "fell through thin ice and drowned"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_bury_any3",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": ["war"],
+        "tags": [],
         "weight": 20,
-        "event_text": "m_c was sealed into a cramped rabbit burrow by o_c warriors. {PRONOUN/m_c/subject/CAP} didn't make it out alive.",
+        "event_text": "m_c was sealed in a cramped rabbit burrow by o_c warriors. {PRONOUN/m_c/subject/CAP} didn't make it out alive.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
             "reg_death": "m_c suffocated underground.",
-            "lead_death": "was suffocated underground."
+            "lead_death": "{VERB/m_c/were/was} suffocated underground."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_murder_multiice2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -2069,16 +2125,13 @@
             "newleaf",
             "leaf-bare"
         ],
-        "tags": [
-            "murder",
-            "revealed"
-        ],
+        "sub_type": [ "murder" ],
+        "tags": [],
         "weight": 20,
         "event_text": "m_c agreed to venture with r_c out onto a frozen pond. m_c went first while r_c hung back. m_c slid around playfully, taunting the other cat to chase {PRONOUN/m_c/object}. {PRONOUN/m_c/subject/CAP} {VERB/m_c/were/was} about to launch another teasing remark when the ice cracked below {PRONOUN/m_c/poss} paws. r_c lingered to make sure {PRONOUN/m_c/subject} didn't surface before running back to camp with a yowl.",
         "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "apprentice", "mediator apprentice", "medicine cat apprentice", "warrior", "medicine cat", "mediator", "deputy" ],
             "not_skill": [
                 "PROPHET,3",
                 "OMEN,3",
@@ -2094,10 +2147,11 @@
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "any" ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c was lured onto thin ice by r_c, resulting in {PRONOUN/m_c/poss} death."
         },
         "relationships": [
@@ -2109,15 +2163,29 @@
                     "m_c"
                 ],
                 "values": [
-                    "dislike",
-                    "platonic"
+                    "dislike"
                 ],
-                "amount": -5
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "platonic",
+                    "trust",
+                    "comfort"
+                ],
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_skirmish_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -2144,7 +2212,9 @@
             "dies": true
         },
         "history": {
-            "reg_death": "m_c died in a border skirmish against o_c."
+            "cats": "m_c",
+            "reg_death": "m_c died in a border skirmish against o_c.",
+            "lead_death": "died in a border skirmish against o_c"
         },
         "other_clan": {
             "current_rep": [
@@ -2155,16 +2225,16 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_war_any9",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "In the chaos of battle and the throes of a war, it's nearly impossible to tell friend from foe. Blinded by blood, r_c accidentally kills m_c.",
         "m_c": {
@@ -2178,7 +2248,6 @@
                 "deputy",
                 "leader"
             ],
-            "relationship_status": [],
             "dies": true
         },
         "r_c": {
@@ -2187,20 +2256,31 @@
                 "adult",
                 "senior adult"
             ],
-            "status": []
+            "status": [ "warrior", "deputy", "leader" ]
         },
         "history": {
-            "reg_death": "m_c was accidentally killed by r_c in battle."
+            "cats": ["m_c", "r_c"],
+            "reg_death": "m_c was accidentally killed by r_c in battle.",
+            "lead_death": "{VERB/m_c/were/was} accidentally killed by r_c in battle"
         },
         "relationships": [
             {
-                "values": [],
-                "amount": 5
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "trust"
+                ],
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_ocsave_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -2239,7 +2319,9 @@
             "dies": true
         },
         "history": {
-            "reg_death": "m_c was killed while trying to save o_c's medicine cat."
+            "cats": "m_c",
+            "reg_death": "m_c was killed while trying to save o_c's medicine cat.",
+            "lead_death": "{VERB/m_c/were/was} killed while trying to save o_c's medicine cat"
         },
         "other_clan": {
             "current_rep": [
@@ -2250,7 +2332,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_ockill_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -2277,7 +2360,9 @@
             "dies": true
         },
         "history": {
-            "reg_death": "m_c was killed by the deputy of o_c."
+            "cats": "m_c",
+            "reg_death": "m_c was killed by the deputy of o_c.",
+            "lead_death": "{VERB/m_c/were/was} killed by the deputy of o_c"
         },
         "other_clan": {
             "current_rep": [
@@ -2288,7 +2373,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_ocsave_any2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -2327,7 +2413,9 @@
             "dies": true
         },
         "history": {
-            "reg_death": "m_c was killed while trying to save o_c's deputy."
+            "cats": "m_c",
+            "reg_death": "m_c was killed while trying to save o_c's deputy.",
+            "lead_death": "{VERB/m_c/were/was} killed while trying to save o_c's deputy"
         },
         "other_clan": {
             "current_rep": [
@@ -2338,7 +2426,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_ockill_any2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -2365,7 +2454,9 @@
             "dies": true
         },
         "history": {
-            "reg_death": "m_c was killed by the leader of o_c."
+            "cats": "m_c",
+            "reg_death": "m_c was killed by the leader of o_c.",
+            "lead_death": "{VERB/m_c/were/was} killed by the leader of o_c"
         },
         "other_clan": {
             "current_rep": [
@@ -2376,7 +2467,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_ocsave_any3",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -2415,7 +2507,9 @@
             "dies": true
         },
         "history": {
-            "reg_death": "m_c was killed while trying to save o_c's leader."
+            "cats": "m_c",
+            "reg_death": "m_c was killed while trying to save o_c's leader.",
+            "lead_death": "{VERB/m_c/were/was} killed while trying to save o_c's leader"
         },
         "other_clan": {
             "current_rep": [
@@ -2426,7 +2520,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_skirmish_any2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -2447,7 +2542,6 @@
                 "deputy",
                 "leader"
             ],
-            "relationship_status": [],
             "not_skill": [
                 "FIGHTER,2"
             ],
@@ -2459,23 +2553,17 @@
                 "adult",
                 "senior adult"
             ],
-            "status": [],
+            "status": [ "warrior", "deputy", "leader" ],
             "not_skill": [
-                "great fighter",
-                "excellent fighter"
+                "FIGHTER,2"
             ],
             "dies": true
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c died in a border skirmish against o_c.",
             "lead_death": "was killed in a border skirmish against o_c."
         },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ],
         "other_clan": {
             "current_rep": [
                 "hostile",
@@ -2485,7 +2573,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_bury_multi1",
+        "biome": ["mountainous", "forest" ],
         "camp": [
             "any"
         ],
@@ -2493,20 +2582,23 @@
             "leaf-fall",
             "leaf-bare"
         ],
-        "tags": [],
+        "tags": [ "all_lives" ],
         "weight": 20,
         "event_text": "m_c was buried alive in an avalanche.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
-            "reg_death": "m_c was buried alive in an avalanche."
+            "cats": "m_c",
+            "reg_death": "m_c was buried alive in an avalanche.",
+            "lead_death": "{VERB/m_c/were/was} buried alive in an avalanche"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_bury_multi2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -2519,16 +2611,19 @@
         "weight": 20,
         "event_text": "m_c was buried alive in a landslide.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
-            "reg_death": "m_c was buried alive in a landslide."
+            "cats": "m_c",
+            "reg_death": "m_c was buried alive in a landslide.",
+            "lead_death": "{VERB/m_c/were/was} buried alive in a landslide"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_bury_newleaf1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -2539,16 +2634,19 @@
         "weight": 20,
         "event_text": "m_c was buried alive in a mudslide.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
-            "reg_death": "m_c was buried alive in a mudslide."
+            "cats": "m_c",
+            "reg_death": "m_c was buried alive in a mudslide.",
+            "lead_death": "{VERB/m_c/were/was} buried alive in a mudslide"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_cliff_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -2559,8 +2657,8 @@
         "weight": 20,
         "event_text": "m_c slipped off a cliff onto the sharp rocks at the bottom.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "any" ],
             "trait": [
                 "playful",
                 "childish"
@@ -2568,86 +2666,27 @@
             "dies": true
         },
         "history": {
-            "reg_death": "m_c slipped off the edge of a cliff."
+            "cats": "m_c",
+            "reg_death": "m_c slipped off the edge of a cliff.",
+            "lead_death": "slipped off the edge of a cliff"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_murder_anycliff1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
-            "leaf-bare"
+            "any"
         ],
+        "sub_type": [ "murder" ],
         "tags": [],
-        "weight": 20,
-        "event_text": "m_c froze to death during a harsh snowstorm.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "dies": true
-        },
-        "history": {
-            "reg_death": "m_c froze to death."
-        }
-    },
-    {
-        "event_id": "gen_death_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was found dead and cold in the snow.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "dies": true
-        },
-        "history": {
-            "reg_death": "m_c froze to death."
-        }
-    },
-    {
-        "event_id": "gen_death_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "leaf-bare"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "m_c was walking on the ice, when it cracked and {PRONOUN/m_c/subject} fell in.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "dies": true
-        },
-        "history": {
-            "reg_death": "m_c froze to death after falling through ice."
-        }
-    },
-    {
-        "event_id": "gen_death_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "murder"
-        ],
         "weight": 20,
         "event_text": "m_c was pushed off a cliff onto the sharp rocks at the bottom. The culprit is unknown.",
         "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "apprentice", "mediator apprentice", "medicine cat apprentice", "warrior", "medicine cat", "mediator", "deputy" ],
             "not_skill": [
                 "PROPHET,3",
                 "OMEN,3",
@@ -2656,14 +2695,15 @@
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "apprentice", "mediator apprentice", "medicine cat apprentice", "warrior", "medicine cat", "mediator", "deputy" ],
             "skill": [
                 "CLEVER,2",
                 "HUNTER,3"
             ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c was pushed off a cliff by r_c."
         },
         "relationships": [
@@ -2675,31 +2715,42 @@
                     "m_c"
                 ],
                 "values": [
-                    "dislike",
-                    "platonic"
+                    "dislike"
                 ],
-                "amount": -5
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "platonic",
+                    "trust",
+                    "comfort"
+                ],
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_murder_anycliff2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "murder",
-            "revealed"
-        ],
+        "sub_type": [ "murder" ],
+        "tags": [],
         "weight": 20,
         "event_text": "m_c was pushed off a cliff onto the sharp rocks at the bottom. r_c stands above {PRONOUN/m_c/object}, watching as they fall.",
         "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult"],
+            "status": [ "apprentice", "mediator apprentice", "medicine cat apprentice", "warrior", "medicine cat", "mediator", "deputy"],
             "not_skill": [
                 "PROPHET,3",
                 "OMEN,3",
@@ -2708,14 +2759,15 @@
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "any" ],
             "skill": [
                 "HUNTER,3",
                 "FIGHTER,2"
             ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c was pushed off a cliff by r_c."
         },
         "relationships": [
@@ -2727,72 +2779,83 @@
                     "m_c"
                 ],
                 "values": [
-                    "dislike",
-                    "platonic"
+                    "dislike"
                 ],
-                "amount": -5
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "platonic",
+                    "trust",
+                    "comfort"
+                ],
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_war_any3",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [ "some_lives"],
         "weight": 20,
         "event_text": "m_c was killed by a falling boulder pushed from a cliff above {PRONOUN/m_c/object} by o_c warriors.",
         "m_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "adult", "young adult", "senior adult" ],
+            "status": [ "apprentice", "warrior", "deputy", "leader" ],
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was crushed by a falling boulder.",
             "lead_death": "{VERB/m_c/were/was} crushed by a falling boulder."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_hawk_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [],
+        "tags": [ "all_lives", "no_body" ],
         "weight": 20,
         "event_text": "r_c, guarding camp, yowls a warning as they spot a circling shadow, right below m_c. r_c starts sprinting to m_c's position, but couldn't get there in time, not before m_c was carried high into the sky.",
         "m_c": {
-            "age": [],
-            "status": [],
-            "relationship_status": [],
+            "age": [ "any" ],
+            "status": [ "any" ],
             "not_skill": [
                 "RUNNER,2"
             ],
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "apprentice", "warrior", "deputy"],
+            "status": [ "any" ]
         },
         "history": {
-            "reg_death": "m_c was grabbed by a hawk, never to be seen again."
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
+            "cats": ["m_c", "r_c"],
+            "reg_death": "m_c was grabbed by a hawk, never to be seen again.",
+            "lead_death": "{VERB/m_c/were/was} grabbed by a hawk, never to be seen again"
+        }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_hawk_any2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -2814,11 +2877,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was taken by a hawk."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_weak_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -2827,7 +2892,7 @@
         ],
         "tags": [],
         "weight": 20,
-        "event_text": "m_c grew weak as the days passed, and now walks the stars of Silverpelt.",
+        "event_text": "m_c grew weak as the days passed and now walks the stars of Silverpelt.",
         "m_c": {
             "age": [
                 "kitten"
@@ -2841,16 +2906,20 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c failed to thrive."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_drown_multi2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
-            "any"
+            "leaf-fall",
+            "newleaf",
+            "greenleaf"
         ],
         "tags": [],
         "weight": 20,
@@ -2869,11 +2938,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c fell into the river and drowned."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_sneak_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -2899,11 +2970,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c died when {PRONOUN/m_c/subject} snuck out of camp."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_poison_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -2929,11 +3002,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c died when {PRONOUN/m_c/subject} got into the herb stores and ate deathberries."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_snake_any3",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -2953,11 +3028,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was killed by a snake."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_kittencough_multi1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -2980,11 +3057,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c died of kittencough."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_whitecough_multi1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3007,11 +3086,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c died of whitecough."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_greencough_multi1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3034,11 +3115,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c died of greencough."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_cold_multi1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3061,11 +3144,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was killed by sickness."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_kittencough_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3090,15 +3175,17 @@
             "age": [
                 "kitten"
             ],
-            "status": [],
+            "status": [ "kitten" ],
             "dies": true
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c died of kittencough."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_whitecough_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3109,7 +3196,7 @@
             "classic"
         ],
         "weight": 20,
-        "event_text": "r_c and m_c catch whitecough, and fade away quickly.",
+        "event_text": "r_c and m_c catch whitecough and fade away quickly.",
         "m_c": {
             "age": [
                 "kitten"
@@ -3123,15 +3210,17 @@
             "age": [
                 "kitten"
             ],
-            "status": [],
+            "status": [ "kitten" ],
             "dies": true
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c died of whitecough."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_greencough_any2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3156,26 +3245,27 @@
             "age": [
                 "kitten"
             ],
-            "status": [],
+            "status": [ "kitten" ],
             "dies": true
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c died of greencough."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_murder_anykit1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "murder"
-        ],
+        "sub_type": [ "murder" ],
+        "tags": [],
         "weight": 20,
-        "event_text": "m_c excitedly follows r_c a short distance from camp to begin the promised battle training. r_c says something about how real warriors don't hold back, even in a spar. m_c nods eagerly. {PRONOUN/m_c/subject/CAP} barely {VERB/m_c/have/has} time to duck as r_c's paw whistles past {PRONOUN/m_c/poss} head. The kit stumbles backwards, tripping over {PRONOUN/m_c/poss} paws, {PRONOUN/m_c/poss} head landing squarely on a rock.",
+        "event_text": "m_c excitedly follows r_c a short distance from camp to begin the promised battle training. r_c says something about how real warriors don't hold back, even in a spar. m_c nods eagerly. {PRONOUN/m_c/subject/CAP} barely {VERB/m_c/have/has} time to duck as r_c's paw whistles past {PRONOUN/m_c/poss} head. The kit stumbles backwards, tripping over {PRONOUN/m_c/poss} paws, {PRONOUN/m_c/poss} head landing hard on a rock.",
         "m_c": {
             "age": [
                 "kitten"
@@ -3183,17 +3273,17 @@
             "status": [
                 "kitten"
             ],
-            "relationship_status": [],
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [ "adolescent", "young adult", "adult", "senior warrior"],
+            "status": [ "apprentice", "warrior", "deputy", "leader"],
             "skill": [
                 "FIGHTER,1"
             ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c was killed in battle training with r_c."
         },
         "relationships": [
@@ -3205,27 +3295,39 @@
                     "m_c"
                 ],
                 "values": [
-                    "dislike",
-                    "platonic"
+                    "dislike"
                 ],
-                "amount": -5
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "platonic",
+                    "trust",
+                    "comfort"
+                ],
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_murder_anykit2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "murder",
-            "revealed"
-        ],
+        "sub_type": [ "murder" ],
+        "tags": [],
         "weight": 20,
-        "event_text": "m_c quietly pads after r_c, eyes bright with the promise of exploring the territory. r_c suddenly comes to a stop beside a spiky bush, pointing at it with a claw. Apparently the shiny red berries taste just like fresh prey, and r_c is offering one to m_c! The kit excitedly nods and grabs a berry with {PRONOUN/m_c/poss} teeth. It's not exactly like prey... the kit's thought trails off as darkness takes over {PRONOUN/m_c/poss} vision.",
+        "event_text": "m_c quietly pads after r_c, eyes bright with the promise of exploring the territory. r_c suddenly comes to a stop beside a spiky bush, pointing at it with a claw. Apparently the shiny red berries taste just like fresh prey, and r_c is offering one to m_c! The kit excitedly nods and grabs a berry with {PRONOUN/m_c/poss} teeth. It's not exactly like prey... The kit's thought trails off as darkness takes over {PRONOUN/m_c/poss} vision.",
         "m_c": {
             "age": [
                 "kitten"
@@ -3233,14 +3335,14 @@
             "status": [
                 "kitten"
             ],
-            "relationship_status": [],
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "apprentice", "warrior", "deputy", "leader" ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c ate deathberries and succumbed to the poison."
         },
         "relationships": [
@@ -3252,15 +3354,29 @@
                     "m_c"
                 ],
                 "values": [
-                    "dislike",
-                    "platonic"
+                    "dislike"
                 ],
-                "amount": -5
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "platonic",
+                    "trust",
+                    "comfort"
+                ],
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_murder_multikit1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3269,10 +3385,8 @@
             "newleaf",
             "leaf-fall"
         ],
-        "tags": [
-            "murder",
-            "revealed"
-        ],
+        "sub_type": [ "murder" ],
+        "tags": [],
         "weight": 20,
         "event_text": "m_c sneaks out of camp, wondering what all is out there. {PRONOUN/m_c/subject/CAP} {VERB/m_c/come/comes} to a small stream and {VERB/m_c/attempt/attempts} to leap across. {PRONOUN/m_c/subject/CAP} misjudged the distance and {PRONOUN/m_c/poss} paws scrabble on the bank for purchase. m_c is losing {PRONOUN/m_c/poss} grip when {PRONOUN/m_c/subject} {VERB/m_c/think/thinks} {PRONOUN/m_c/subject} {VERB/m_c/catch/catches} a glimpse of r_c's pelt. {PRONOUN/m_c/subject/CAP}{VERB/m_c/'re/'s} about to call for help when {PRONOUN/m_c/poss} grip fails.",
         "m_c": {
@@ -3282,7 +3396,6 @@
             "status": [
                 "kitten"
             ],
-            "relationship_status": [],
             "trait": [
                 "daring",
                 "troublesome",
@@ -3293,10 +3406,11 @@
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "adolescent", "young adult", "adult", "senior adult"],
+            "status": [ "any" ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c drowned in a stream while r_c watched."
         },
         "relationships": [
@@ -3308,15 +3422,29 @@
                     "m_c"
                 ],
                 "values": [
-                    "dislike",
-                    "platonic"
+                    "dislike"
                 ],
-                "amount": -5
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "platonic",
+                    "trust",
+                    "comfort"
+                ],
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_ockill_anymed1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3325,7 +3453,7 @@
         ],
         "tags": [],
         "weight": 20,
-        "event_text": "o_c warriors broke into the camp and killed m_c, after damaging the herb stores.",
+        "event_text": "o_c warriors broke into the camp and killed m_c after damaging the herb stores.",
         "m_c": {
             "age": [
                 "young adult",
@@ -3344,6 +3472,7 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was killed when o_c warriors broke into camp."
         },
         "other_clan": {
@@ -3354,7 +3483,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_ockill_anymed2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3363,16 +3493,17 @@
         ],
         "tags": [],
         "weight": 20,
-        "event_text": "m_c was killed by a o_c warrior while pulling an injured Clanmate away from battle.",
+        "event_text": "m_c was killed by a o_c warrior while pulling an injured r_c away from battle.",
         "m_c": {
             "age": [
+                "adolescent",
                 "young adult",
                 "adult",
                 "senior adult",
                 "senior"
             ],
             "status": [
-                "medicine cat"
+                "medicine cat apprentice", "medicine cat"
             ],
             "relationship_status": [],
             "not_skill": [
@@ -3394,10 +3525,11 @@
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "adolescent", "young adult", "adult", "senior adult"],
+            "status": [ "apprentice", "warrior", "deputy", "leader"]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c was killed by a o_c warrior while trying to aid an injured Clanmate."
         },
         "relationships": [
@@ -3412,7 +3544,7 @@
                     "trust",
                     "respect"
                 ],
-                "amount": 5
+                "amount": 15
             }
         ],
         "other_clan": {
@@ -3423,7 +3555,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_greencough_leafbaremed1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3434,7 +3567,7 @@
             "classic"
         ],
         "weight": 20,
-        "event_text": "m_c caught greencough while caring for {PRONOUN/m_c/poss} patients, and couldn't manage to fight it off.",
+        "event_text": "m_c caught greencough while caring for {PRONOUN/m_c/poss} patients and couldn't manage to fight it off.",
         "m_c": {
             "age": [
                 "young adult",
@@ -3460,11 +3593,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c died of greencough."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_wander_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3473,25 +3608,25 @@
         ],
         "tags": [],
         "weight": 20,
-        "event_text": "m_c wandered out into the territory, and was later found dead.",
+        "event_text": "m_c wandered out into the territory and was later found dead.",
         "m_c": {
             "age": [
-                "senior",
                 "adolescent",
                 "young adult",
                 "adult",
-                "senior adult",
-                "elder"
+                "senior adult"
             ],
             "status": [],
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c died while wandering the territory."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_fox_any2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3503,22 +3638,23 @@
         "event_text": "m_c was having a peaceful stroll outside of camp, when {PRONOUN/m_c/subject} {VERB/m_c/were/was} attacked and killed by a fox.",
         "m_c": {
             "age": [
-                "senior",
                 "adolescent",
                 "young adult",
                 "adult",
-                "senior adult",
-                "elder"
+                "senior adult"
             ],
-            "status": [],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
-            "reg_death": "m_c was killed by a fox."
+            "cats": "m_c",
+            "reg_death": "m_c was killed by a fox.",
+            "lead_death": "{VERB/m_c/were/was} killed by a fox"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_badger_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3530,22 +3666,23 @@
         "event_text": "m_c was having a peaceful stroll outside of camp, when {PRONOUN/m_c/subject} {VERB/m_c/were/was} attacked and killed by a badger.",
         "m_c": {
             "age": [
-                "senior",
                 "adolescent",
                 "young adult",
                 "adult",
-                "senior adult",
-                "elder"
+                "senior adult"
             ],
-            "status": [],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
-            "reg_death": "m_c was killed by a badger."
+            "cats": "m_c",
+            "reg_death": "m_c was killed by a badger.",
+            "lead_death": "{VERB/m_c/were/was} killed by a badger"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_dog_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3557,22 +3694,23 @@
         "event_text": "m_c was having a peaceful stroll outside of camp, when {PRONOUN/m_c/subject} {VERB/m_c/were/was} attacked and killed by a dog.",
         "m_c": {
             "age": [
-                "senior",
                 "adolescent",
                 "young adult",
                 "adult",
-                "senior adult",
-                "elder"
+                "senior adult"
             ],
-            "status": [],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
-            "reg_death": "m_c was killed by a dog."
+            "cats": "m_c",
+            "reg_death": "m_c was killed by a dog.",
+            "lead_death": "{VERB/m_c/were/was} killed by a dog"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_whitecough_leafbare1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3590,18 +3728,20 @@
                 "adolescent",
                 "young adult",
                 "adult",
-                "senior adult",
-                "elder"
+                "senior adult"
             ],
-            "status": [],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
-            "reg_death": "m_c died of whitecough."
+            "cats": "m_c",
+            "reg_death": "m_c died of whitecough.",
+            "lead_death": "died of whitecough"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_illness_leafbare1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3612,25 +3752,27 @@
             "classic"
         ],
         "weight": 20,
-        "event_text": "m_c was too weak to recover from an illness, and passed away.",
+        "event_text": "m_c was too weak to recover from an illness and passed away.",
         "m_c": {
             "age": [
-                "senior",
                 "adolescent",
                 "young adult",
                 "adult",
                 "senior adult",
-                "elder"
+                "senior"
             ],
-            "status": [],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
-            "reg_death": "m_c was killed by sickness."
+            "cats": "m_c",
+            "reg_death": "m_c succumbed to illness.",
+            "lead_death": "succumbed to illness"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_whitecough_leafbare2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3648,18 +3790,20 @@
                 "adolescent",
                 "young adult",
                 "adult",
-                "senior adult",
-                "elder"
+                "senior adult"
             ],
-            "status": [],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
-            "reg_death": "m_c died of whitecough."
+            "cats": "m_c",
+            "reg_death": "m_c died of whitecough.",
+            "lead_death": "died of whitecough"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_greencough_leafbare2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3677,27 +3821,28 @@
                 "adolescent",
                 "young adult",
                 "adult",
-                "senior adult",
-                "elder"
+                "senior adult"
             ],
             "status": [],
             "dies": true
         },
         "history": {
-            "reg_death": "m_c died of greencough."
+            "cats": "m_c",
+            "reg_death": "m_c died of greencough.",
+            "lead_death": "died of greencough"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_stress_anywar1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "m_c suffered a heart attack due to the stress of the ongoing war.",
         "m_c": {
@@ -3706,18 +3851,20 @@
                 "adolescent",
                 "young adult",
                 "adult",
-                "senior adult",
-                "elder"
+                "senior adult"
             ],
             "status": [],
             "dies": true
         },
         "history": {
-            "reg_death": "m_c died of a heart attack due to stress."
+            "cats": "m_c",
+            "reg_death": "m_c died of a heart attack due to stress.",
+            "lead_death": "died of a heart attack due to stress"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_lightning_multilead1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3742,11 +3889,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "{VERB/m_c/were/was} struck by lightning"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_fox_anylead1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3755,7 +3904,7 @@
         ],
         "tags": [],
         "weight": 20,
-        "event_text": "m_c was mortally wounded by a fox, and lost a life.",
+        "event_text": "m_c was mortally wounded by a fox and lost a life.",
         "m_c": {
             "age": [
                 "young adult",
@@ -3772,11 +3921,12 @@
             "dies": true
         },
         "history": {
-            "lead_death": "{VERB/m_c/were/was} wounded by a fox"
+            "cats": "m_c",
+            "lead_death": "{VERB/m_c/were/was} mortally wounded by a fox"
         }
     },
     {
-        "event_id": "gen_death_tree_anyleader",
+        "event_id": "gen_death_tree_anylead1",
         "biome": [ "beach", "forest", "mountainous" ],
         "camp": [
             "any"
@@ -3784,9 +3934,7 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "some_lives"
-        ],
+        "tags": [],
         "weight": 20,
         "event_text": "m_c lost a life when {PRONOUN/m_c/subject} fell from the top branches of a tree.",
         "m_c": {
@@ -3809,7 +3957,8 @@
     ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_dog_anylead1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3835,11 +3984,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "{VERB/m_c/were/was} mauled by a dog"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_badger_anylead1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3865,11 +4016,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "{VERB/m_c/were/was} killed by a badger"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_rogue_anylead1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3895,11 +4048,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "fought a rogue"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_spider_anylead1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3922,11 +4077,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "{VERB/m_c/were/was} bit by a venomous spider"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_snake_anylead1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3949,11 +4106,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "{VERB/m_c/were/was} bit by a venomous snake"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_badprey_anylead1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3962,7 +4121,7 @@
         ],
         "tags": [],
         "weight": 20,
-        "event_text": "m_c ate tainted fresh-kill, and lost a life.",
+        "event_text": "m_c ate tainted fresh-kill and lost a life.",
         "m_c": {
             "age": [
                 "young adult",
@@ -3976,11 +4135,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "ate tainted fresh-kill"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_warned_anylead1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -3989,7 +4150,7 @@
         ],
         "tags": [],
         "weight": 20,
-        "event_text": "m_c failed to interpret a warning sign from StarClan, and lost a life as a result.",
+        "event_text": "m_c failed to interpret a warning sign from StarClan and lost a life as a result.",
         "m_c": {
             "age": [
                 "young adult",
@@ -4007,11 +4168,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "failed to interpret a warning from StarClan"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_dog_anylead2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -4031,7 +4194,6 @@
             "status": [
                 "leader"
             ],
-            "relationship_status": [],
             "not_skill": [
                 "FIGHTER,2"
             ],
@@ -4052,10 +4214,11 @@
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "any" ],
+            "status": [ "any" ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "lead_death": "defended r_c from a dog"
         },
         "relationships": [
@@ -4070,15 +4233,27 @@
                     "platonic",
                     "comfort",
                     "trust",
-                    "respect",
+                    "respect"
+                ],
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
                     "dislike"
                 ],
-                "amount": -5
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_badger_anylead2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -4098,7 +4273,6 @@
             "status": [
                 "leader"
             ],
-            "relationship_status": [],
             "not_skill": [
                 "FIGHTER,3"
             ],
@@ -4119,10 +4293,11 @@
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "any" ],
+            "status": [ "any" ]
         },
         "history": {
+            "cats": ["m_c", "r_c" ],
             "lead_death": "defended r_c from a badger"
         },
         "relationships": [
@@ -4137,15 +4312,27 @@
                     "platonic",
                     "comfort",
                     "trust",
-                    "respect",
+                    "respect"
+                ],
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
                     "dislike"
                 ],
-                "amount": -5
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_fox_anylead2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -4186,10 +4373,11 @@
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "any" ],
+            "status": [ "any" ]
         },
         "history": {
+            "cats": [ "m_c", "r_c"],
             "lead_death": "defended r_c from a fox"
         },
         "relationships": [
@@ -4204,15 +4392,27 @@
                     "platonic",
                     "comfort",
                     "trust",
-                    "respect",
+                    "respect"
+                ],
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
                     "dislike"
                 ],
-                "amount": -5
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_drown_anylead1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -4232,7 +4432,6 @@
             "status": [
                 "leader"
             ],
-            "relationship_status": [],
             "trait": [
                 "bold",
                 "compassionate",
@@ -4248,10 +4447,11 @@
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "any" ],
+            "status": [ "any" ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "lead_death": "saved r_c from drowning"
         },
         "relationships": [
@@ -4266,15 +4466,27 @@
                     "platonic",
                     "comfort",
                     "trust",
-                    "respect",
+                    "respect"
+                ],
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
                     "dislike"
                 ],
-                "amount": -5
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_monster_anylead1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -4294,7 +4506,6 @@
             "status": [
                 "leader"
             ],
-            "relationship_status": [],
             "trait": [
                 "bold",
                 "ambitious",
@@ -4310,10 +4521,11 @@
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "any" ],
+            "status": [ "any" ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "lead_death": "saved r_c from a monster"
         },
         "relationships": [
@@ -4328,15 +4540,27 @@
                     "platonic",
                     "comfort",
                     "trust",
-                    "respect",
+                    "respect"
+                ],
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
                     "dislike"
                 ],
-                "amount": -5
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_snake_anylead2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -4356,7 +4580,6 @@
             "status": [
                 "leader"
             ],
-            "relationship_status": [],
             "trait": [
                 "bold",
                 "ambitious",
@@ -4374,10 +4597,11 @@
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "any" ],
+            "status": [ "any" ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "lead_death": "saved r_c from a snake"
         },
         "relationships": [
@@ -4392,15 +4616,27 @@
                     "platonic",
                     "comfort",
                     "trust",
-                    "respect",
+                    "respect"
+                ],
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
                     "dislike"
                 ],
-                "amount": -5
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_ockill_anylead1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -4443,6 +4679,7 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "defended the kits from o_c warriors"
         },
         "other_clan": {
@@ -4453,7 +4690,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_ockill_anylead2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -4495,10 +4733,11 @@
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "adolescent", "young adult", "adult", "senior adult" ],
+            "status": [ "apprentice", "warrior", "medicine cat apprentice", "medicine cat", "deputy"]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "lead_death": "defended r_c from o_c warriors"
         },
         "relationships": [
@@ -4513,10 +4752,21 @@
                     "platonic",
                     "comfort",
                     "trust",
-                    "respect",
+                    "respect"
+                ],
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
                     "dislike"
                 ],
-                "amount": -5
+                "amount": -15
             }
         ],
         "other_clan": {
@@ -4528,7 +4778,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_ockill_anylead3",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -4554,6 +4805,7 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "fought an apprentice from o_c"
         },
         "other_clan": {
@@ -4565,7 +4817,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_ocsave_anylead1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -4603,6 +4856,7 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "saved an apprentice from o_c"
         },
         "other_clan": {
@@ -4614,7 +4868,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_ockill_anylead4",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -4640,6 +4895,7 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "fought a warrior from o_c"
         },
         "other_clan": {
@@ -4651,7 +4907,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_ocsave_anylead2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -4689,6 +4946,7 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "saved a warrior from o_c"
         },
         "other_clan": {
@@ -4700,7 +4958,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_ockill_anylead5",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -4726,6 +4985,7 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "fought the o_c leader"
         },
         "other_clan": {
@@ -4737,7 +4997,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_ocsave_anylead3",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -4775,6 +5036,7 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "saved the o_c leader"
         },
         "other_clan": {
@@ -4786,7 +5048,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_ockill_anylead6",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -4812,6 +5075,7 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "fought the o_c deputy"
         },
         "other_clan": {
@@ -4823,7 +5087,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_ocsave_anylead4",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -4861,6 +5126,7 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "saved the o_c deputy"
         },
         "other_clan": {
@@ -4872,17 +5138,16 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_age_anylead1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "old_age",
-            "some_lives"
-        ],
+        "sub_type": [ "old_age" ],
+        "tags": [],
         "weight": 20,
         "event_text": "m_c lost some lives to {PRONOUN/m_c/poss} old age.",
         "m_c": {
@@ -4898,21 +5163,21 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "succumbed to old age"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_age_anylead2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "old_age",
-            "all_lives"
-        ],
+        "sub_type": [ "old_age" ],
+        "tags": [ "all_lives" ],
         "weight": 20,
         "event_text": "m_c's body just couldn't continue forward - {PRONOUN/m_c/subject}{VERB/m_c/'ve/'s} lost all of {PRONOUN/m_c/poss} remaining lives to old age.",
         "m_c": {
@@ -4928,11 +5193,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "succumbed to old age"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_rogue_anylead2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -4960,11 +5227,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "{VERB/m_c/were/was} brutally attacked by a rogue"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_dog_anylead3",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -4975,7 +5244,7 @@
             "all_lives"
         ],
         "weight": 20,
-        "event_text": "m_c was mauled by dogs, and lost all of {PRONOUN/m_c/poss} lives.",
+        "event_text": "m_c was mauled by dogs and lost all of {PRONOUN/m_c/poss} lives.",
         "m_c": {
             "age": [
                 "young adult",
@@ -4992,11 +5261,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "{VERB/m_c/were/was} mauled by dogs"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_fire_anylead1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -5034,11 +5305,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "{VERB/m_c/were/was} killed in a fire trying to save {PRONOUN/m_c/poss} Clanmates"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_ockill_anylead7",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -5066,6 +5339,7 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "{VERB/m_c/were/was} brutally murdered by a warrior from o_c"
         },
         "other_clan": {
@@ -5076,7 +5350,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_ockill_anylead8",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -5104,6 +5379,7 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "{VERB/m_c/were/was} brutally murdered by the leader of o_c"
         },
         "other_clan": {
@@ -5114,7 +5390,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_ockill_anylead9",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -5142,6 +5419,7 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "{VERB/m_c/were/was} brutally murdered by the deputy of o_c"
         },
         "other_clan": {
@@ -5152,7 +5430,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_greencough_multilead1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -5178,11 +5457,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "contracted greencough"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_greencough_multilead2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -5195,7 +5476,7 @@
             "some_lives"
         ],
         "weight": 20,
-        "event_text": "m_c caught greencough, and died more than once, despite the efforts of StarClan.",
+        "event_text": "m_c caught greencough and died more than once, despite the efforts of StarClan.",
         "m_c": {
             "age": [
                 "young adult",
@@ -5209,11 +5490,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "contracted greencough"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_whitecough_multilead1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -5239,11 +5522,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "contracted whitecough"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_whitecough_multilead2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -5256,7 +5541,7 @@
             "some_lives"
         ],
         "weight": 20,
-        "event_text": "m_c caught whitecough, and died more than once, despite the efforts of StarClan.",
+        "event_text": "m_c caught whitecough and died more than once, despite the efforts of StarClan.",
         "m_c": {
             "age": [
                 "young adult",
@@ -5270,11 +5555,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "contracted whitecough"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_yellowcough_multilead1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -5300,11 +5587,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "contracted yellowcough"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_yellowcough_multilead2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -5317,7 +5606,7 @@
             "some_lives"
         ],
         "weight": 20,
-        "event_text": "m_c caught yellowcough, and died more than once, despite the efforts of StarClan.",
+        "event_text": "m_c caught yellowcough and died more than once, despite the efforts of StarClan.",
         "m_c": {
             "age": [
                 "young adult",
@@ -5331,11 +5620,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "contracted yellowcough"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_infection_multilead1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -5361,11 +5652,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "killed by infected wounds"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_age_anylead3",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -5380,8 +5673,6 @@
         "event_text": "m_c lost lives to old age, {PRONOUN/m_c/poss} body slowly becoming more and more frail.",
         "m_c": {
             "age": [
-                "young adult",
-                "adult",
                 "senior adult",
                 "senior"
             ],
@@ -5391,27 +5682,27 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "died of old age"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_age_anylead4",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
+        "sub_type": [ "old_age" ],
         "tags": [
-            "old_age",
             "all_lives"
         ],
         "weight": 20,
         "event_text": "m_c collapses in the midst of camp, losing {PRONOUN/m_c/poss} remaining lives to old age.",
         "m_c": {
             "age": [
-                "young adult",
-                "adult",
                 "senior adult",
                 "senior"
             ],
@@ -5421,26 +5712,25 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "died of old age"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_age_anylead5",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "old_age"
-        ],
+        "sub_type": [ "old_age" ],
+        "tags": [ ],
         "weight": 20,
         "event_text": "One day, the deputy finds m_c dead in the leader's den. Seems {PRONOUN/m_c/subject} lost a life to old age.",
         "m_c": {
             "age": [
-                "young adult",
-                "adult",
                 "senior adult",
                 "senior"
             ],
@@ -5450,27 +5740,27 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "died of old age"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_age_anylead6",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
+        "sub_type": [ "old_age" ],
         "tags": [
-            "old_age",
             "all_lives"
         ],
         "weight": 20,
         "event_text": "One day, m_c is found dead in the leader's den, never to rise again. Seems {PRONOUN/m_c/subject} lost the rest of {PRONOUN/m_c/poss} lives to old age.",
         "m_c": {
             "age": [
-                "young adult",
-                "adult",
                 "senior adult",
                 "senior"
             ],
@@ -5480,27 +5770,27 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "died of old age"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_age_anylead7",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
+        "sub_type": [ "old_age" ],
         "tags": [
-            "old_age",
             "all_lives"
         ],
         "weight": 20,
         "event_text": "Despite StarClan's efforts, m_c's body just couldn't continue. {PRONOUN/m_c/poss/CAP} remaining lives were taken by old age.",
         "m_c": {
             "age": [
-                "young adult",
-                "adult",
                 "senior adult",
                 "senior"
             ],
@@ -5510,22 +5800,23 @@
             "dies": true
         },
         "history": {
+            "m_c": "m_c",
             "lead_death": "died of old age"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_murder_anylead1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "murder"
-        ],
+        "sub_type": [ "murder" ],
+        "tags": [],
         "weight": 20,
-        "event_text": "m_c was pushed under a monster, and lost a life.",
+        "event_text": "m_c was pushed under a monster and lost a life.",
         "m_c": {
             "age": [
                 "young adult",
@@ -5554,42 +5845,60 @@
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "adolescent", "young adult", "adult", "senior adult", "senior" ],
+            "status": [ "apprentice", "mediator apprentice", "medicine cat apprentice", "medicine cat", "mediator", "warrior", "deputy" ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "lead_death": "{VERB/m_c/were/was} pushed under a monster by r_c"
         },
         "relationships": [
             {
-                "mututal": true,
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
                 "values": [
-                    "dislike",
                     "platonic",
                     "comfort",
-                    "trust",
-                    "respect"
+                    "trust"
                 ],
-                "amount": -5
+                "amount": -15
+            },
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": 15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_murder_anylead2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "all_lives",
+        "sub_type": [
             "murder",
-            "revealed",
-            "jealousy"
+            "murder_reveal"
+        ],
+        "tags": [
+            "all_lives"
         ],
         "weight": 20,
-        "event_text": "m_c was murdered by r_c in cold blood, with the intention of taking {PRONOUN/m_c/poss} place.",
+        "event_text": "m_c was murdered by r_c in cold blood in order to take {PRONOUN/m_c/poss} place.",
         "m_c": {
             "age": [
                 "young adult",
@@ -5606,8 +5915,8 @@
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [ "young adult", "adult", "senior adult" ],
+            "status": [ "deputy" ],
             "skill": [
                 "FIGHTER,2"
             ],
@@ -5622,6 +5931,7 @@
             ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "lead_death": "{VERB/m_c/were/was} murdered by r_c"
         },
         "relationships": [
@@ -5635,24 +5945,23 @@
                 "values": [
                     "platonic"
                 ],
-                "amount": -5
+                "amount": -15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_murder_anylead3",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "murder",
-            "revealed"
-        ],
+        "sub_type": [ "murder" ],
+        "tags": [],
         "weight": 20,
-        "event_text": "m_c was murdered by r_c, with the intention of taking {PRONOUN/m_c/poss} place, but r_c miscalculated how many lives m_c had left! m_c retaliated, killing r_c in self defense.",
+        "event_text": "m_c was murdered by r_c, intending to take {PRONOUN/m_c/poss} place, but r_c miscalculated how many lives m_c had left! m_c retaliated by killing r_c in self defense.",
         "m_c": {
             "age": [
                 "young adult",
@@ -5669,8 +5978,8 @@
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [ "any" ],
+            "status": [ "deputy" ],
             "not_skill": [
                 "CLEVER,2",
                 "CLEVER,3"
@@ -5686,8 +5995,9 @@
             ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c was killed by r_c in self-defense.",
-            "lead_death": "{VERB/m_c/were/was} murdered by r_c in an attempt to usurp {PRONOUN/m_c/poss} lead"
+            "lead_death": "{VERB/m_c/were/was} murdered by r_c in an attempt to usurp {PRONOUN/m_c/poss} position"
         },
         "relationships": [
             {
@@ -5698,27 +6008,38 @@
                     "r_c"
                 ],
                 "values": [
-                    "dislike",
                     "platonic",
                     "trust",
                     "respect"
                 ],
-                "amount": -5
+                "amount": -15
+            },
+            {
+                "cats_from": [
+                    "m_c"
+                ],
+                "cats_to": [
+                    "r_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": 15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_murder_anylead4",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
+        "sub_type": [ "murder" ],
         "tags": [
-            "all_lives",
-            "murder",
-            "revealed"
+            "all_lives"
         ],
         "weight": 20,
         "event_text": "m_c and r_c were on a walk together when a pack of dogs caught them off guard. m_c prepared to fight, but when {PRONOUN/m_c/subject} looked to r_c for backup, the other cat was nowhere to be found. r_c watched quietly as the dogs took life after life from m_c.",
@@ -5738,8 +6059,8 @@
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": []
+            "age": [ "young adult", "adult", "senior adult" ],
+            "status": [ "any" ]
         },
         "history": {
             "lead_death": "{VERB/m_c/were/was} indirectly murdered by r_c in a fatal dog attack"
@@ -5753,26 +6074,37 @@
                     "m_c"
                 ],
                 "values": [
-                    "dislike",
                     "platonic",
                     "trust",
                     "respect"
                 ],
-                "amount": -5
+                "amount": -15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
+                    "dislike"
+                ],
+                "amount": 15
             }
         ]
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_war_anyfriendlyfire1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "In the chaos of battle and the throes of a war, it's nearly impossible to tell friend from foe. Blinded by blood, r_c accidentally kills m_c. m_c lost one life.",
         "m_c": {
@@ -5797,7 +6129,7 @@
                 "adult",
                 "senior adult"
             ],
-            "status": [],
+            "status": [ "apprentice", "warrior", "deputy" ],
             "skill": [
                 "FIGHTER,1"
             ],
@@ -5810,26 +6142,22 @@
             ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c was accidentally attacked by m_c in battle.",
             "lead_death": "{VERB/m_c/were/was} accidentally attacked by r_c in the chaos of battle"
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
+        }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_age_anylead8",
+        "biome": ["any"],
         "camp": [
-            "Any"
+            "any"
         ],
         "season": [
             "any"
         ],
+        "sub_type": [ "old_age" ],
         "tags": [
-            "old_age",
             "all_lives"
         ],
         "weight": 20,
@@ -5850,22 +6178,18 @@
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [ "senior" ],
+            "status": [ "any" ],
             "dies": true
         },
         "history": {
+            "cats": [ "m_c", "r_c"],
             "lead_death": "died of old age"
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ]
+        }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_curious_anylead1",
+        "biome": ["any"],
         "camp": [
             "Any"
         ],
@@ -5874,13 +6198,10 @@
         ],
         "tags": [],
         "weight": 20,
-        "event_text": "m_c has always wondered where {PRONOUN/m_c/subject} came from. {PRONOUN/m_c/subject/CAP} {VERB/m_c/sneak/sneaks} out of camp, intending to find loners who might have some clues about {PRONOUN/m_c/poss} origins. Frantic with worry and confusion after finding m_c's empty nest in the morning, they launch a search. c_n finds {PRONOUN/m_c/poss} cooling body after a long search and wonders why {PRONOUN/m_c/subject} decided to leave the safety of c_n, and what killed {PRONOUN/m_c/object}.",
+        "event_text": "m_c has always wondered where {PRONOUN/m_c/subject} came from. {PRONOUN/m_c/subject/CAP} {VERB/m_c/sneak/sneaks} out of camp, intending to find loners who might have some clues about {PRONOUN/m_c/poss} origins. Frantic with worry and confusion after finding m_c's empty nest in the morning, they launch a search. c_n finds m_c stumbling back to camp, pelt haggard and eyes haunted.",
         "m_c": {
             "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
+                "young adult"
             ],
             "status": [
                 "leader"
@@ -5893,11 +6214,13 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "lead_death": "became a bit too curious"
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_ockill_anylead10",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -5906,7 +6229,7 @@
         ],
         "tags": [],
         "weight": 20,
-        "event_text": "o_c attempted to break into the camp. m_c died defending the nursery, r_c left hidden beneath {PRONOUN/m_c/poss} cooling body.",
+        "event_text": "o_c attempted to break into the camp. m_c died defending the nursery. r_c remained hidden beneath {PRONOUN/m_c/poss} body as StarClan brought m_c back to life.",
         "m_c": {
             "age": [
                 "young adult",
@@ -5917,7 +6240,6 @@
             "status": [
                 "leader"
             ],
-            "relationship_status": [],
             "trait": [
                 "vengeful",
                 "bloodthirsty",
@@ -5937,17 +6259,12 @@
             "age": [
                 "kitten"
             ],
-            "status": []
+            "status": [ "any" ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "lead_death": "defended r_c from o_c warriors"
         },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ],
         "other_clan": {
             "current_rep": [
                 "hostile"
@@ -5956,107 +6273,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [],
-        "weight": 20,
-        "event_text": "o_c attempted to break into the camp. m_c and r_c are left cold on the ground in the aftermath.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "leader"
-            ],
-            "relationship_status": [],
-            "dies": true
-        },
-        "r_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult"
-            ],
-            "status": [],
-            "dies": true
-        },
-        "history": {
-            "reg_death": "This cat died when o_c tried to break into camp.",
-            "lead_death": "tried to defend the Clan from o_c"
-        },
-        "relationships": [
-            {
-                "values": [],
-                "amount": 5
-            }
-        ],
-        "other_clan": {
-            "current_rep": [
-                "hostile"
-            ],
-            "changed": -5
-        }
-    },
-    {
-        "event_id": "gen_death_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "any"
-        ],
-        "tags": [
-            "all_lives",
-            "murder",
-            "revealed",
-            "jealousy"
-        ],
-        "weight": 20,
-        "event_text": "A yowl took m_c by surprise as {PRONOUN/m_c/subject} {VERB/m_c/were/was} patrolling the territory. r_c suddenly crashed into view, meowing about how m_c had to come and see. m_c followed the distressed warrior to a small ravine. {PRONOUN/m_c/subject/CAP} peered over the edge, and noted the sharp rocks at the bottom. Suddenly, {PRONOUN/m_c/subject} felt a sharp shove from behind, letting out a yowl of surprise that was cut short as {PRONOUN/m_c/subject} landed on the rocks.",
-        "m_c": {
-            "age": [
-                "young adult",
-                "adult",
-                "senior adult",
-                "senior"
-            ],
-            "status": [
-                "leader"
-            ],
-            "dies": true
-        },
-        "r_c": {
-            "age": [],
-            "status": []
-        },
-        "history": {
-            "lead_death": "{VERB/m_c/were/was} pushed into a ravine by r_c"
-        },
-        "relationships": [
-            {
-                "cats_from": [
-                    "r_c"
-                ],
-                "cats_to": [
-                    "m_c"
-                ],
-                "values": [
-                    "platonic"
-                ],
-                "amount": -5
-            }
-        ]
-    },
-    {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_train_any1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -6068,7 +6286,7 @@
         "event_text": "m_c died in a training accident.",
         "m_c": {
             "age": [
-                "adolescent"
+                "adolescent", "young adult"
             ],
             "status": [
                 "apprentice"
@@ -6076,18 +6294,18 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c died in a training accident."
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_ockill_anyapp1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
-            "greenleaf",
-            "leaf-fall",
-            "leaf-bare"
+            "any"
         ],
         "tags": [],
         "weight": 20,
@@ -6109,6 +6327,7 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was killed by o_c warriors after accidentally trespassing."
         },
         "other_clan": {
@@ -6120,7 +6339,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_ockill_anyapp2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -6129,7 +6349,7 @@
         ],
         "tags": [],
         "weight": 20,
-        "event_text": "m_c was killed by o_c warriors after deliberately going over the border.",
+        "event_text": "m_c was killed by o_c warriors after deliberately crossing the border.",
         "m_c": {
             "age": [
                 "adolescent"
@@ -6155,6 +6375,7 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was killed by o_c warriors after deliberately trespassing."
         },
         "other_clan": {
@@ -6166,7 +6387,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_skirmish_anyapp1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -6178,7 +6400,7 @@
         "event_text": "m_c died in a border skirmish against o_c.",
         "m_c": {
             "age": [
-                "adolescent"
+                "adolescent", "young adult"
             ],
             "status": [
                 "apprentice"
@@ -6186,6 +6408,7 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c died in a border skirmish against o_c."
         },
         "other_clan": {
@@ -6197,7 +6420,8 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_skirmish_anyapp2",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
@@ -6209,7 +6433,7 @@
         "event_text": "m_c and r_c are killed in a border skirmish against o_c.",
         "m_c": {
             "age": [
-                "adolescent"
+                "adolescent", "young adult"
             ],
             "status": [
                 "apprentice"
@@ -6221,16 +6445,17 @@
         },
         "r_c": {
             "age": [
-                "adolescent"
+                "adolescent", "young adult"
             ],
-            "status": [],
+            "status": [ "apprentice" ],
             "not_skill": [
-                "great fighter",
-                "excellent fighter"
+                "FIGHTER,3",
+                "FIGHTER,4"
             ],
             "dies": true
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c died in a border skirmish against o_c."
         },
         "other_clan": {
@@ -6242,36 +6467,37 @@
         }
     },
     {
-        "event_id": "gen_death_",
+        "event_id": "gen_death_murder_anyapp1",
+        "biome": ["any"],
         "camp": [
             "any"
         ],
         "season": [
             "any"
         ],
-        "tags": [
-            "murder"
-        ],
+        "sub_type": [ "murder" ],
+        "tags": [],
         "weight": 20,
         "event_text": "m_c enters {PRONOUN/m_c/poss} battle stance, staring down r_c, who wanted to assess the apprentice's skills. m_c dashes forward, getting in some hits on r_c's side, before scampering out of range. Feeling bolder, the apprentice goes in for another attack from the other side. r_c spins around at the last second, {PRONOUN/r_c/poss} claws catching m_c across the throat.",
         "m_c": {
             "age": [
-                "adolescent"
+                "adolescent", "young adult"
             ],
             "status": [
                 "apprentice"
             ],
-            "relationship_status": [],
+            "relationship_status": ["app/mentor"],
             "dies": true
         },
         "r_c": {
-            "age": [],
-            "status": [],
+            "age": [ "any" ],
+            "status": [ "any"],
             "skill": [
                 "FIGHTER,1"
             ]
         },
         "history": {
+            "cats": ["m_c", "r_c"],
             "reg_death": "m_c was killed in battle training with r_c."
         },
         "relationships": [
@@ -6283,10 +6509,21 @@
                     "m_c"
                 ],
                 "values": [
-                    "dislike",
+                    "dislike"
+                ],
+                "amount": 15
+            },
+            {
+                "cats_from": [
+                    "r_c"
+                ],
+                "cats_to": [
+                    "m_c"
+                ],
+                "values": [
                     "platonic"
                 ],
-                "amount": -5
+                "amount": -15
             }
         ]
     }

--- a/resources/dicts/events/death/mountainous.json
+++ b/resources/dicts/events/death/mountainous.json
@@ -510,7 +510,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was buried alive in an avalanche."
         }
     },
@@ -533,7 +533,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was buried alive in a landslide."
         }
     },
@@ -554,7 +554,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was buried alive in a mudslide."
         }
     },
@@ -674,7 +674,7 @@
             ]
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was pushed off a cliff by r_c."
         },
         "relationships": [
@@ -725,7 +725,7 @@
             ]
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was pushed off a cliff by r_c."
         },
         "relationships": [
@@ -752,7 +752,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was killed by a falling boulder pushed from a cliff above {PRONOUN/m_c/object} by o_c warriors.",
@@ -762,7 +762,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was crushed by a falling boulder.",
             "lead_death": "{VERB/m_c/were/was} crushed by a falling boulder."
         }
@@ -792,7 +792,7 @@
             "status": []
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was grabbed by a hawk, never to be seen again."
         },
         "relationships": [

--- a/resources/dicts/events/death/mountainous.json
+++ b/resources/dicts/events/death/mountainous.json
@@ -510,6 +510,7 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was buried alive in an avalanche."
         }
     },
@@ -532,6 +533,7 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was buried alive in a landslide."
         }
     },
@@ -552,6 +554,7 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was buried alive in a mudslide."
         }
     },
@@ -647,9 +650,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "murder"
-        ],
+        "sub_type": [ "murder" ],
+        "tags": [],
         "weight": 20,
         "event_text": "m_c was pushed off a cliff onto the sharp rocks at the bottom. The culprit is unknown.",
         "m_c": {
@@ -672,6 +674,7 @@
             ]
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was pushed off a cliff by r_c."
         },
         "relationships": [
@@ -698,10 +701,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "murder",
-            "revealed"
-        ],
+        "sub_type": [ "murder", "revealed" ],
+        "tags": [],
         "weight": 20,
         "event_text": "m_c was pushed off a cliff onto the sharp rocks at the bottom. r_c stands above {PRONOUN/m_c/object}, watching as they fall.",
         "m_c": {
@@ -724,6 +725,7 @@
             ]
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was pushed off a cliff by r_c."
         },
         "relationships": [
@@ -750,9 +752,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "m_c was killed by a falling boulder pushed from a cliff above {PRONOUN/m_c/object} by o_c warriors.",
         "m_c": {
@@ -761,6 +762,7 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was crushed by a falling boulder.",
             "lead_death": "{VERB/m_c/were/was} crushed by a falling boulder."
         }
@@ -790,6 +792,7 @@
             "status": []
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was grabbed by a hawk, never to be seen again."
         },
         "relationships": [

--- a/resources/dicts/events/death/mountainous.json
+++ b/resources/dicts/events/death/mountainous.json
@@ -701,7 +701,7 @@
         "season": [
             "any"
         ],
-        "sub_type": [ "murder", "revealed" ],
+        "sub_type": [ "murder" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was pushed off a cliff onto the sharp rocks at the bottom. r_c stands above {PRONOUN/m_c/object}, watching as they fall.",

--- a/resources/dicts/events/death/plains.json
+++ b/resources/dicts/events/death/plains.json
@@ -588,7 +588,7 @@
             "newleaf",
             "leaf-bare"
         ],
-        "sub_type": [ "murder", "revealed" ],
+        "sub_type": [ "murder" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c agreed to venture with r_c out onto a frozen pond. m_c went first while r_c hung back. m_c slid around playfully, taunting the other cat to chase {PRONOUN/m_c/object}. {PRONOUN/m_c/subject/CAP} {VERB/m_c/were/was} about to launch another teasing remark when the ice cracked below {PRONOUN/m_c/poss} paws. r_c lingered to make sure {PRONOUN/m_c/subject} didn't surface before running back to camp with a yowl.",

--- a/resources/dicts/events/death/plains.json
+++ b/resources/dicts/events/death/plains.json
@@ -493,7 +493,7 @@
             "dies": true
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was buried alive when a burrow collapsed."
         }
     },
@@ -565,7 +565,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c was sealed into a cramped rabbit burrow by o_c warriors. {PRONOUN/m_c/subject/CAP} didn't make it out alive.",
@@ -615,7 +615,7 @@
             "status": []
         },
         "history": {
-            "cats": "m_c",
+            "cats": ["m_c"],
             "reg_death": "m_c was lured onto thin ice by r_c, resulting in {PRONOUN/m_c/poss} death."
         },
         "relationships": [

--- a/resources/dicts/events/death/plains.json
+++ b/resources/dicts/events/death/plains.json
@@ -493,29 +493,8 @@
             "dies": true
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was buried alive when a burrow collapsed."
-        }
-    },
-    {
-        "event_id": "pln_death_",
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf"
-        ],
-        "tags": [
-            "classic"
-        ],
-        "weight": 20,
-        "event_text": "m_c died from dehydration and heat stroke.",
-        "m_c": {
-            "age": [],
-            "status": [],
-            "dies": true
-        },
-        "history": {
-            "reg_death": "m_c died of dehydration and heat stroke."
         }
     },
     {
@@ -586,9 +565,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "m_c was sealed into a cramped rabbit burrow by o_c warriors. {PRONOUN/m_c/subject/CAP} didn't make it out alive.",
         "m_c": {
@@ -610,10 +588,8 @@
             "newleaf",
             "leaf-bare"
         ],
-        "tags": [
-            "murder",
-            "revealed"
-        ],
+        "sub_type": [ "murder", "revealed" ],
+        "tags": [],
         "weight": 20,
         "event_text": "m_c agreed to venture with r_c out onto a frozen pond. m_c went first while r_c hung back. m_c slid around playfully, taunting the other cat to chase {PRONOUN/m_c/object}. {PRONOUN/m_c/subject/CAP} {VERB/m_c/were/was} about to launch another teasing remark when the ice cracked below {PRONOUN/m_c/poss} paws. r_c lingered to make sure {PRONOUN/m_c/subject} didn't surface before running back to camp with a yowl.",
         "m_c": {
@@ -639,6 +615,7 @@
             "status": []
         },
         "history": {
+            "cats": "m_c",
             "reg_death": "m_c was lured onto thin ice by r_c, resulting in {PRONOUN/m_c/poss} death."
         },
         "relationships": [
@@ -774,34 +751,5 @@
         },
         "history": {
             "reg_death": "m_c froze to death after falling through ice."
-        }
-    },
-    {
-        "event_id": "pln_death_",
-        "biome": [
-            "plains"
-        ],
-        "camp": [
-            "any"
-        ],
-        "season": [
-            "greenleaf"
-        ],
-        "tags": [
-            "classic"
-        ],
-        "weight": 20,
-        "event_text": "m_c died from dehydration and heat stroke.",
-        "m_c": {
-            "age": [
-                "kitten"
-            ],
-            "status": [
-                "kitten"
-            ],
-            "dies": true
-        },
-        "history": {
-            "reg_death": "m_c died of dehydration and heat stroke."
         }
     }]

--- a/resources/dicts/events/misc_events/beach.json
+++ b/resources/dicts/events/misc_events/beach.json
@@ -10,7 +10,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "The apprentices of the Clan are taking special training to learn how to disguise their scents from enemies with kelp and seawater.",
@@ -92,7 +92,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c sits by the water, contemplating the calm waves that brush {PRONOUN/m_c/poss} paws and wondering why those times are not as peaceful as the tides.",

--- a/resources/dicts/events/misc_events/beach.json
+++ b/resources/dicts/events/misc_events/beach.json
@@ -10,9 +10,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "The apprentices of the Clan are taking special training to learn how to disguise their scents from enemies with kelp and seawater.",
         "m_c": {
@@ -93,9 +92,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "m_c sits by the water, contemplating the calm waves that brush {PRONOUN/m_c/poss} paws and wondering why those times are not as peaceful as the tides.",
         "m_c": {

--- a/resources/dicts/events/misc_events/forest.json
+++ b/resources/dicts/events/misc_events/forest.json
@@ -72,9 +72,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "The apprentices of the Clan are taking special training to learn how to land on enemies when jumping from trees.",
         "m_c": {

--- a/resources/dicts/events/misc_events/forest.json
+++ b/resources/dicts/events/misc_events/forest.json
@@ -72,7 +72,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "The apprentices of the Clan are taking special training to learn how to land on enemies when jumping from trees.",

--- a/resources/dicts/events/misc_events/general.json
+++ b/resources/dicts/events/misc_events/general.json
@@ -518,9 +518,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "m_c's knowledge of herbs and healing is being put to the test, with injuries becoming more severe in the midst of war.",
         "m_c": {
@@ -543,9 +542,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "m_c watches every little thing around {PRONOUN/m_c/object} for any omen that indicates what the Clan should do in the war. The losses weigh heavy on the hearts of every cat.",
         "m_c": {
@@ -571,9 +569,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "m_c preps battle herbs into small bundles to rush to the battlefield in case of severe injuries.",
         "m_c": {
@@ -593,9 +590,8 @@
         "season": [
             "leaf-bare"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "m_c hopes to find the herbs that c_n needs in the war, and goes to look for them even in this leafbare's harsh weather.",
         "m_c": {
@@ -618,9 +614,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "c_n is in a badly need of herbs, and m_c knows it, but can't bring {PRONOUN/m_c/self} to leave {PRONOUN/m_c/poss} patients' side.",
         "m_c": {
@@ -1498,9 +1493,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "As the deputy, m_c is doing {PRONOUN/m_c/poss} best to prepare for leadership in the case that the worst happens.",
         "m_c": {
@@ -1522,9 +1516,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "m_c is struggling to accept the fact that {PRONOUN/m_c/subject} may have to step up as leader if r_c loses {PRONOUN/r_c/poss} last life. How could {PRONOUN/m_c/subject} {VERB/m_c/go/goes} on without {PRONOUN/m_c/poss} beloved leader? How difficult will it to be to lead in {PRONOUN/r_c/poss} stead?",
         "m_c": {
@@ -1572,9 +1565,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "m_c is struggling to accept the fact that {PRONOUN/m_c/subject} may have to step up as leader if r_c loses {PRONOUN/r_c/poss} last life.",
         "m_c": {
@@ -1617,9 +1609,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "m_c is heavily relying on the tactical advice and experience of the elders, namely r_c.",
         "m_c": {
@@ -2764,9 +2755,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "m_c feels like {PRONOUN/m_c/subject} might be growing up too fast in the midst of war.",
         "m_c": {
@@ -2936,9 +2926,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "m_c is conversing with r_c about ways to potentially end this war without bloodshed.",
         "m_c": {
@@ -2996,9 +2985,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "m_c is conversing with r_c about ways to potentially end this war- but not without bloodshed.",
         "m_c": {
@@ -3056,9 +3044,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "m_c is giving r_c bad war advice on purpose.",
         "m_c": {
@@ -3116,9 +3103,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "m_c is checking in on every cat in the camp to make sure everyone is staying healthy in the midst of war.",
         "m_c": {
@@ -3299,9 +3285,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "m_c feels burdened with the weight of {PRONOUN/m_c/poss} decisions, knowing that every choice they make could mean the difference between victory and defeat.",
         "m_c": {
@@ -3324,9 +3309,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "m_c's relationships with {PRONOUN/m_c/poss} Clanmates are strained, with some questioning {PRONOUN/m_c/poss} decisions and others relying on {PRONOUN/m_c/object} more heavily than ever.",
         "m_c": {
@@ -3349,9 +3333,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "m_c is forced to be a symbol of strength and unity for {PRONOUN/m_c/poss} Clan, even in the face of {PRONOUN/m_c/poss} own doubts and fears.",
         "m_c": {

--- a/resources/dicts/events/misc_events/general.json
+++ b/resources/dicts/events/misc_events/general.json
@@ -518,7 +518,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c's knowledge of herbs and healing is being put to the test, with injuries becoming more severe in the midst of war.",
@@ -542,7 +542,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c watches every little thing around {PRONOUN/m_c/object} for any omen that indicates what the Clan should do in the war. The losses weigh heavy on the hearts of every cat.",
@@ -569,7 +569,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c preps battle herbs into small bundles to rush to the battlefield in case of severe injuries.",
@@ -590,7 +590,7 @@
         "season": [
             "leaf-bare"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c hopes to find the herbs that c_n needs in the war, and goes to look for them even in this leafbare's harsh weather.",
@@ -614,7 +614,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "c_n is in a badly need of herbs, and m_c knows it, but can't bring {PRONOUN/m_c/self} to leave {PRONOUN/m_c/poss} patients' side.",
@@ -1493,7 +1493,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "As the deputy, m_c is doing {PRONOUN/m_c/poss} best to prepare for leadership in the case that the worst happens.",
@@ -1516,7 +1516,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c is struggling to accept the fact that {PRONOUN/m_c/subject} may have to step up as leader if r_c loses {PRONOUN/r_c/poss} last life. How could {PRONOUN/m_c/subject} {VERB/m_c/go/goes} on without {PRONOUN/m_c/poss} beloved leader? How difficult will it to be to lead in {PRONOUN/r_c/poss} stead?",
@@ -1565,7 +1565,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c is struggling to accept the fact that {PRONOUN/m_c/subject} may have to step up as leader if r_c loses {PRONOUN/r_c/poss} last life.",
@@ -1609,7 +1609,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c is heavily relying on the tactical advice and experience of the elders, namely r_c.",
@@ -2755,7 +2755,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c feels like {PRONOUN/m_c/subject} might be growing up too fast in the midst of war.",
@@ -2926,7 +2926,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c is conversing with r_c about ways to potentially end this war without bloodshed.",
@@ -2985,7 +2985,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c is conversing with r_c about ways to potentially end this war- but not without bloodshed.",
@@ -3044,7 +3044,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c is giving r_c bad war advice on purpose.",
@@ -3103,7 +3103,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c is checking in on every cat in the camp to make sure everyone is staying healthy in the midst of war.",
@@ -3285,7 +3285,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c feels burdened with the weight of {PRONOUN/m_c/poss} decisions, knowing that every choice they make could mean the difference between victory and defeat.",
@@ -3309,7 +3309,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c's relationships with {PRONOUN/m_c/poss} Clanmates are strained, with some questioning {PRONOUN/m_c/poss} decisions and others relying on {PRONOUN/m_c/object} more heavily than ever.",
@@ -3333,7 +3333,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "m_c is forced to be a symbol of strength and unity for {PRONOUN/m_c/poss} Clan, even in the face of {PRONOUN/m_c/poss} own doubts and fears.",

--- a/resources/dicts/events/misc_events/mountainous.json
+++ b/resources/dicts/events/misc_events/mountainous.json
@@ -10,7 +10,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "The apprentices of the Clan are taking special strength training to learn how to weaponize stones and boulders in the mountain landscape.",

--- a/resources/dicts/events/misc_events/mountainous.json
+++ b/resources/dicts/events/misc_events/mountainous.json
@@ -10,9 +10,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "The apprentices of the Clan are taking special strength training to learn how to weaponize stones and boulders in the mountain landscape.",
         "m_c": {

--- a/resources/dicts/events/misc_events/plains.json
+++ b/resources/dicts/events/misc_events/plains.json
@@ -68,9 +68,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "The apprentices of the Clan are taking special training to learn how to survive in underground tunnels long-term, in the case of a siege conducted by o_c.",
         "m_c": {

--- a/resources/dicts/events/misc_events/plains.json
+++ b/resources/dicts/events/misc_events/plains.json
@@ -68,7 +68,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "The apprentices of the Clan are taking special training to learn how to survive in underground tunnels long-term, in the case of a siege conducted by o_c.",

--- a/resources/dicts/events/new_cat/general.json
+++ b/resources/dicts/events/new_cat/general.json
@@ -696,9 +696,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "A member of o_c defects in the war and chooses to join c_n. {PRONOUN/n_c/subject/CAP} {VERB/n_c/decide/decides} to keep {PRONOUN/n_c/poss} name.",
         "m_c": {
@@ -748,9 +747,8 @@
         "season": [
             "any"
         ],
-        "tags": [
-            "war"
-        ],
+        "sub_type": "war",
+        "tags": [],
         "weight": 20,
         "event_text": "n_c, the deputy of o_c, has defected to c_n in the war. {PRONOUN/n_c/subject/CAP} {VERB/n_c/decide/decides} to keep {PRONOUN/n_c/poss} name.",
         "m_c": {

--- a/resources/dicts/events/new_cat/general.json
+++ b/resources/dicts/events/new_cat/general.json
@@ -696,7 +696,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "A member of o_c defects in the war and chooses to join c_n. {PRONOUN/n_c/subject/CAP} {VERB/n_c/decide/decides} to keep {PRONOUN/n_c/poss} name.",
@@ -747,7 +747,7 @@
         "season": [
             "any"
         ],
-        "sub_type": "war",
+        "sub_type": [ "war" ],
         "tags": [],
         "weight": 20,
         "event_text": "n_c, the deputy of o_c, has defected to c_n in the war. {PRONOUN/n_c/subject/CAP} {VERB/n_c/decide/decides} to keep {PRONOUN/n_c/poss} name.",


### PR DESCRIPTION
also correcting a bunch of war tags to be subtype: war instead (which is why many files are affected other than just the deaths\general.json)

I deleted some events which were specific to the beach biome; once I begin reviewing the forest deaths I can see that a lot of them will need to be moved over to the general.json because they are not biome specific.

I made the vast majority of the biomes "any" just to be safe; lemme know if you have particular directions on which events need to be biome specific